### PR TITLE
Tradelock feedback

### DIFF
--- a/packages/eeg-web/src/__mocks__/eeg_wasm.cjs
+++ b/packages/eeg-web/src/__mocks__/eeg_wasm.cjs
@@ -1,3 +1,110 @@
+// Mock WASM result objects
+
+class MockAlphaBumpResult {
+	get alpha_power() { return 0.8; }
+	get baseline() { return 0.5; }
+	get state() { return 'high'; }
+	get state_changed() { return false; }
+	get previous_state() { return undefined; }
+	is_high() { return true; }
+	is_low() { return false; }
+	free() {}
+}
+
+class MockAlphaPeakResult {
+	get alpha_power() { return 0.6; }
+	get long_term_peak_frequency() { return 10.2; }
+	get peak_frequency() { return 10.5; }
+	get peak_power() { return 0.9; }
+	get smoothed_peak_frequency() { return 10.3; }
+	get snr() { return 3.1; }
+	free() {}
+}
+
+class MockCalmnessResult {
+	get alpha_beta_ratio() { return 1.4; }
+	get alpha_power() { return 0.6; }
+	get beta_power() { return 0.3; }
+	get score() { return 0.7; }
+	get smoothed_score() { return 0.65; }
+	get theta_level() { return 0.2; }
+	get theta_power() { return 0.15; }
+	percentage() { return 70; }
+	state_description() { return 'calm'; }
+	free() {}
+}
+
+class MockWasmAlphaBumpDetector {
+	constructor(_sampleRate, _channelCount) {
+		this._callCount = 0;
+	}
+	min_samples() { return 256; }
+	name() { return 'AlphaBumpDetector'; }
+	process(_data) {
+		this._callCount++;
+		return this._callCount === 1 ? undefined : new MockAlphaBumpResult();
+	}
+	reset() { this._callCount = 0; }
+	set_baseline_smoothing(_alpha) {}
+	set_threshold(_multiplier) {}
+	free() {}
+}
+
+class MockWasmAlphaPeakModel {
+	constructor(_sampleRate, _channelCount) {
+		this._callCount = 0;
+	}
+	min_samples() { return 256; }
+	name() { return 'AlphaPeakModel'; }
+	process(_data) {
+		this._callCount++;
+		return this._callCount === 1 ? undefined : new MockAlphaPeakResult();
+	}
+	reset() { this._callCount = 0; }
+	set_smoothing(_alpha) {}
+	free() {}
+}
+
+class MockWasmCalmnessModel {
+	constructor(_sampleRate, _channelCount) {
+		this._callCount = 0;
+	}
+	min_samples() { return 256; }
+	name() { return 'CalmnessModel'; }
+	process(_data) {
+		this._callCount++;
+		return this._callCount === 1 ? undefined : new MockCalmnessResult();
+	}
+	reset() { this._callCount = 0; }
+	set_smoothing(_alpha) {}
+	free() {}
+}
+
+class MockWasmBandPowers {
+	constructor(opts = {}) {
+		this._relative = opts.relative || false;
+		this.delta = opts.delta || 0.1;
+		this.theta = opts.theta || 0.15;
+		this.alpha = opts.alpha || 0.4;
+		this.beta = opts.beta || 0.25;
+		this.gamma = opts.gamma || 0.1;
+		this.total = opts.total || 1.0;
+	}
+	relative() {
+		const t = this.delta + this.theta + this.alpha + this.beta + this.gamma;
+		return new MockWasmBandPowers({
+			relative: true,
+			delta: this.delta / t,
+			theta: this.theta / t,
+			alpha: this.alpha / t,
+			beta: this.beta / t,
+			gamma: this.gamma / t,
+			total: 1.0,
+		});
+	}
+	free() {}
+}
+
 module.exports = {
 	default: function initWasm(moduleOrPath) {
 		return Promise.resolve({ initializedWith: moduleOrPath });
@@ -9,4 +116,8 @@ module.exports = {
 	doSomething: function doSomething() {
 		return "ok";
 	},
+	WasmAlphaBumpDetector: MockWasmAlphaBumpDetector,
+	WasmAlphaPeakModel: MockWasmAlphaPeakModel,
+	WasmCalmnessModel: MockWasmCalmnessModel,
+	band_powers: (_data, _sampleRate) => new MockWasmBandPowers(),
 };

--- a/packages/eeg-web/src/__tests__/models.test.ts
+++ b/packages/eeg-web/src/__tests__/models.test.ts
@@ -1,0 +1,190 @@
+import {
+	AlphaBumpDetector,
+	AlphaPeakModel,
+	CalmnessModel,
+	band_powers_relative,
+} from '../models';
+
+const SAMPLE_RATE = 256;
+const CHANNEL_COUNT = 4;
+const chunk = new Float32Array(CHANNEL_COUNT * 10); // 10 samples, 4 channels
+
+// ---------------------------------------------------------------------------
+// band_powers_relative
+// ---------------------------------------------------------------------------
+
+describe('band_powers_relative', () => {
+	it('returns a plain object with relative band powers', () => {
+		const result = band_powers_relative(new Float32Array(256), SAMPLE_RATE);
+		expect(result).toHaveProperty('delta');
+		expect(result).toHaveProperty('theta');
+		expect(result).toHaveProperty('alpha');
+		expect(result).toHaveProperty('beta');
+		expect(result).toHaveProperty('gamma');
+		expect(result).toHaveProperty('total');
+	});
+
+	it('sums band powers close to total', () => {
+		const result = band_powers_relative(new Float32Array(256), SAMPLE_RATE);
+		const sum = result.delta + result.theta + result.alpha + result.beta + result.gamma;
+		expect(sum).toBeCloseTo(result.total, 5);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AlphaBumpDetector
+// ---------------------------------------------------------------------------
+
+describe('AlphaBumpDetector', () => {
+	it('returns NotReady on first process call', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		const result = det.process(chunk);
+		expect(result.ready).toBe(false);
+		det.free();
+	});
+
+	it('NotReady result includes samplesNeeded', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		const result = det.process(chunk);
+		expect(result.ready).toBe(false);
+		if (!result.ready) {
+			expect(typeof result.samplesNeeded).toBe('number');
+			expect(result.samplesNeeded).toBeGreaterThanOrEqual(0);
+		}
+		det.free();
+	});
+
+	it('returns a reading once warm', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		det.process(chunk); // first call → undefined from mock
+		const result = det.process(chunk); // second call → result from mock
+		expect(result.ready).toBe(true);
+		if (result.ready) {
+			expect(typeof result.alpha_power).toBe('number');
+			expect(typeof result.baseline).toBe('number');
+			expect(typeof result.state).toBe('string');
+			expect(typeof result.state_changed).toBe('boolean');
+			expect(typeof result.is_high).toBe('boolean');
+			expect(typeof result.is_low).toBe('boolean');
+		}
+		det.free();
+	});
+
+	it('tracks samplesBuffered across calls', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		expect(det.samplesBuffered).toBe(0);
+		det.process(chunk); // 10 samples/channel * 4 channels / 4 = 10
+		expect(det.samplesBuffered).toBe(10);
+		det.process(chunk);
+		expect(det.samplesBuffered).toBe(20);
+		det.free();
+	});
+
+	it('samplesNeeded decreases as samples arrive', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		const before = det.samplesNeeded;
+		det.process(chunk);
+		expect(det.samplesNeeded).toBeLessThan(before);
+		det.free();
+	});
+
+	it('reset clears samplesBuffered', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		det.process(chunk);
+		det.reset();
+		expect(det.samplesBuffered).toBe(0);
+		det.free();
+	});
+
+	it('exposes minSamples and name', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		expect(det.minSamples).toBe(256);
+		expect(det.name).toBe('AlphaBumpDetector');
+		det.free();
+	});
+
+	it('supports Symbol.dispose', () => {
+		const det = new AlphaBumpDetector(SAMPLE_RATE, CHANNEL_COUNT);
+		expect(() => det[Symbol.dispose]()).not.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AlphaPeakModel
+// ---------------------------------------------------------------------------
+
+describe('AlphaPeakModel', () => {
+	it('returns NotReady on first process call', () => {
+		const model = new AlphaPeakModel(SAMPLE_RATE, CHANNEL_COUNT);
+		const result = model.process(chunk);
+		expect(result.ready).toBe(false);
+		model.free();
+	});
+
+	it('returns a reading once warm', () => {
+		const model = new AlphaPeakModel(SAMPLE_RATE, CHANNEL_COUNT);
+		model.process(chunk);
+		const result = model.process(chunk);
+		expect(result.ready).toBe(true);
+		if (result.ready) {
+			expect(typeof result.peak_frequency).toBe('number');
+			expect(typeof result.alpha_power).toBe('number');
+			expect(typeof result.snr).toBe('number');
+		}
+		model.free();
+	});
+
+	it('reset clears samplesBuffered', () => {
+		const model = new AlphaPeakModel(SAMPLE_RATE, CHANNEL_COUNT);
+		model.process(chunk);
+		model.reset();
+		expect(model.samplesBuffered).toBe(0);
+		model.free();
+	});
+
+	it('supports Symbol.dispose', () => {
+		const model = new AlphaPeakModel(SAMPLE_RATE, CHANNEL_COUNT);
+		expect(() => model[Symbol.dispose]()).not.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// CalmnessModel
+// ---------------------------------------------------------------------------
+
+describe('CalmnessModel', () => {
+	it('returns NotReady on first process call', () => {
+		const model = new CalmnessModel(SAMPLE_RATE, CHANNEL_COUNT);
+		const result = model.process(chunk);
+		expect(result.ready).toBe(false);
+		model.free();
+	});
+
+	it('returns a reading once warm', () => {
+		const model = new CalmnessModel(SAMPLE_RATE, CHANNEL_COUNT);
+		model.process(chunk);
+		const result = model.process(chunk);
+		expect(result.ready).toBe(true);
+		if (result.ready) {
+			expect(typeof result.score).toBe('number');
+			expect(typeof result.smoothed_score).toBe('number');
+			expect(typeof result.alpha_beta_ratio).toBe('number');
+			expect(typeof result.percentage).toBe('number');
+			expect(typeof result.state_description).toBe('string');
+		}
+		model.free();
+	});
+
+	it('reset clears samplesBuffered', () => {
+		const model = new CalmnessModel(SAMPLE_RATE, CHANNEL_COUNT);
+		model.process(chunk);
+		model.reset();
+		expect(model.samplesBuffered).toBe(0);
+		model.free();
+	});
+
+	it('supports Symbol.dispose', () => {
+		const model = new CalmnessModel(SAMPLE_RATE, CHANNEL_COUNT);
+		expect(() => model[Symbol.dispose]()).not.toThrow();
+	});
+});

--- a/packages/eeg-web/src/index.ts
+++ b/packages/eeg-web/src/index.ts
@@ -21,6 +21,7 @@ export function initEegWasmSync(
 
 export type { InitInput, InitOutput };
 export * from "./headband";
+export * from "./models";
 
 export * from "../wasm/eeg_wasm.js";
 export { wasm };

--- a/packages/eeg-web/src/models.ts
+++ b/packages/eeg-web/src/models.ts
@@ -1,0 +1,318 @@
+import {
+	WasmAlphaBumpDetector,
+	WasmAlphaPeakModel,
+	WasmCalmnessModel,
+	band_powers as wasmBandPowers,
+} from "../wasm/eeg_wasm.js";
+
+// ---------------------------------------------------------------------------
+// Shared
+// ---------------------------------------------------------------------------
+
+/** Returned by process() when the model has not yet seen enough samples. */
+export type NotReady = { ready: false; samplesNeeded: number };
+
+// ---------------------------------------------------------------------------
+// Band powers
+// ---------------------------------------------------------------------------
+
+export interface BandPowersReading {
+	delta: number;
+	theta: number;
+	alpha: number;
+	beta: number;
+	gamma: number;
+	total: number;
+}
+
+/**
+ * Compute band powers and return relative values (each band as a fraction of
+ * total) as a plain object. Frees both WASM heap objects automatically.
+ */
+export function band_powers_relative(
+	data: Float32Array,
+	sample_rate: number,
+): BandPowersReading {
+	const abs = wasmBandPowers(data, sample_rate);
+	const rel = abs.relative();
+	try {
+		return {
+			delta: rel.delta,
+			theta: rel.theta,
+			alpha: rel.alpha,
+			beta: rel.beta,
+			gamma: rel.gamma,
+			total: rel.total,
+		};
+	} finally {
+		rel.free();
+		abs.free();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Alpha bump
+// ---------------------------------------------------------------------------
+
+export interface AlphaBumpReading {
+	ready: true;
+	alpha_power: number;
+	baseline: number;
+	state: string;
+	state_changed: boolean;
+	previous_state: string | undefined;
+	is_high: boolean;
+	is_low: boolean;
+}
+
+/**
+ * Wrapper around WasmAlphaBumpDetector that:
+ * - Returns a discriminated union from process() instead of bare undefined
+ * - Tracks how many samples have been buffered
+ * - Automatically frees WASM result objects
+ */
+export class AlphaBumpDetector {
+	private inner: WasmAlphaBumpDetector;
+	private readonly _channelCount: number;
+	private _samplesBuffered = 0;
+
+	constructor(sample_rate: number, channel_count: number) {
+		this.inner = new WasmAlphaBumpDetector(sample_rate, channel_count);
+		this._channelCount = channel_count;
+	}
+
+	get minSamples(): number {
+		return this.inner.min_samples();
+	}
+
+	get samplesBuffered(): number {
+		return this._samplesBuffered;
+	}
+
+	get samplesNeeded(): number {
+		return Math.max(0, this.inner.min_samples() - this._samplesBuffered);
+	}
+
+	get name(): string {
+		return this.inner.name();
+	}
+
+	process(data: Float32Array): NotReady | AlphaBumpReading {
+		this._samplesBuffered += Math.floor(data.length / this._channelCount);
+		const result = this.inner.process(data);
+		if (result === undefined) {
+			return { ready: false, samplesNeeded: this.samplesNeeded };
+		}
+		try {
+			return {
+				ready: true,
+				alpha_power: result.alpha_power,
+				baseline: result.baseline,
+				state: result.state,
+				state_changed: result.state_changed,
+				previous_state: result.previous_state,
+				is_high: result.is_high(),
+				is_low: result.is_low(),
+			};
+		} finally {
+			result.free();
+		}
+	}
+
+	reset(): void {
+		this._samplesBuffered = 0;
+		this.inner.reset();
+	}
+
+	set_baseline_smoothing(alpha: number): void {
+		this.inner.set_baseline_smoothing(alpha);
+	}
+
+	set_threshold(multiplier: number): void {
+		this.inner.set_threshold(multiplier);
+	}
+
+	free(): void {
+		this.inner.free();
+	}
+
+	[Symbol.dispose](): void {
+		this.free();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Alpha peak
+// ---------------------------------------------------------------------------
+
+export interface AlphaPeakReading {
+	ready: true;
+	alpha_power: number;
+	long_term_peak_frequency: number;
+	peak_frequency: number;
+	peak_power: number;
+	smoothed_peak_frequency: number;
+	snr: number;
+}
+
+/**
+ * Wrapper around WasmAlphaPeakModel that:
+ * - Returns a discriminated union from process() instead of bare undefined
+ * - Tracks how many samples have been buffered
+ * - Automatically frees WASM result objects
+ */
+export class AlphaPeakModel {
+	private inner: WasmAlphaPeakModel;
+	private readonly _channelCount: number;
+	private _samplesBuffered = 0;
+
+	constructor(sample_rate: number, channel_count: number) {
+		this.inner = new WasmAlphaPeakModel(sample_rate, channel_count);
+		this._channelCount = channel_count;
+	}
+
+	get minSamples(): number {
+		return this.inner.min_samples();
+	}
+
+	get samplesBuffered(): number {
+		return this._samplesBuffered;
+	}
+
+	get samplesNeeded(): number {
+		return Math.max(0, this.inner.min_samples() - this._samplesBuffered);
+	}
+
+	get name(): string {
+		return this.inner.name();
+	}
+
+	process(data: Float32Array): NotReady | AlphaPeakReading {
+		this._samplesBuffered += Math.floor(data.length / this._channelCount);
+		const result = this.inner.process(data);
+		if (result === undefined) {
+			return { ready: false, samplesNeeded: this.samplesNeeded };
+		}
+		try {
+			return {
+				ready: true,
+				alpha_power: result.alpha_power,
+				long_term_peak_frequency: result.long_term_peak_frequency,
+				peak_frequency: result.peak_frequency,
+				peak_power: result.peak_power,
+				smoothed_peak_frequency: result.smoothed_peak_frequency,
+				snr: result.snr,
+			};
+		} finally {
+			result.free();
+		}
+	}
+
+	reset(): void {
+		this._samplesBuffered = 0;
+		this.inner.reset();
+	}
+
+	set_smoothing(alpha: number): void {
+		this.inner.set_smoothing(alpha);
+	}
+
+	free(): void {
+		this.inner.free();
+	}
+
+	[Symbol.dispose](): void {
+		this.free();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Calmness
+// ---------------------------------------------------------------------------
+
+export interface CalmnessReading {
+	ready: true;
+	alpha_beta_ratio: number;
+	alpha_power: number;
+	beta_power: number;
+	score: number;
+	smoothed_score: number;
+	theta_level: number;
+	theta_power: number;
+	percentage: number;
+	state_description: string;
+}
+
+/**
+ * Wrapper around WasmCalmnessModel that:
+ * - Returns a discriminated union from process() instead of bare undefined
+ * - Tracks how many samples have been buffered
+ * - Automatically frees WASM result objects
+ */
+export class CalmnessModel {
+	private inner: WasmCalmnessModel;
+	private readonly _channelCount: number;
+	private _samplesBuffered = 0;
+
+	constructor(sample_rate: number, channel_count: number) {
+		this.inner = new WasmCalmnessModel(sample_rate, channel_count);
+		this._channelCount = channel_count;
+	}
+
+	get minSamples(): number {
+		return this.inner.min_samples();
+	}
+
+	get samplesBuffered(): number {
+		return this._samplesBuffered;
+	}
+
+	get samplesNeeded(): number {
+		return Math.max(0, this.inner.min_samples() - this._samplesBuffered);
+	}
+
+	get name(): string {
+		return this.inner.name();
+	}
+
+	process(data: Float32Array): NotReady | CalmnessReading {
+		this._samplesBuffered += Math.floor(data.length / this._channelCount);
+		const result = this.inner.process(data);
+		if (result === undefined) {
+			return { ready: false, samplesNeeded: this.samplesNeeded };
+		}
+		try {
+			return {
+				ready: true,
+				alpha_beta_ratio: result.alpha_beta_ratio,
+				alpha_power: result.alpha_power,
+				beta_power: result.beta_power,
+				score: result.score,
+				smoothed_score: result.smoothed_score,
+				theta_level: result.theta_level,
+				theta_power: result.theta_power,
+				percentage: result.percentage(),
+				state_description: result.state_description(),
+			};
+		} finally {
+			result.free();
+		}
+	}
+
+	reset(): void {
+		this._samplesBuffered = 0;
+		this.inner.reset();
+	}
+
+	set_smoothing(alpha: number): void {
+		this.inner.set_smoothing(alpha);
+	}
+
+	free(): void {
+		this.inner.free();
+	}
+
+	[Symbol.dispose](): void {
+		this.free();
+	}
+}


### PR DESCRIPTION
**Summary**
- Adds `AlphaBumpDetector`, `AlphaPeakModel`, `CalmnessModel` wrapper classes and `band_powers_relative()` over the raw wasm-bindgen output
- `process()` now returns `NotReady | <Reading>` instead of bare `undefined` — `NotReady` carries `samplesNeeded` so callers always know why they got no result
- Sample progress exposed via `.samplesBuffered` / `.samplesNeeded`
- WASM result objects freed automatically in `try/finally` — callers never handle heap-allocated results
- Raw WASM classes still re-exported, so fully non-breaking

**Motivation**

Feedback from a downstream consumer ([tradelock](https://github.com/...)) who had to build their own accumulator on top because `process()` gave no signal on why it returned `undefined`, and hit silent memory leaks from unfreed result objects.

**Test plan**
- [ ] `pnpm test` passes in `packages/eeg-web`
- [ ] Verify `NotReady` path returns correct `samplesNeeded`
- [ ] Verify warm path returns plain JS reading object (no `.free()` needed)

---

Want me to swap in the actual downstream link or adjust the tone?