### PR TITLE
feat(rppg-web): Face Mesh alignment and TradeLock-style guidance

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,42 +1,112 @@
-# Rust build artifacts (601MB)
-target/
-*.rs.bk
-Cargo.lock
-
-# Node dependencies (145MB)
-node_modules/
-.pnpm-store/
-pnpm-lock.yaml
-
-# Git
+# Version control
 .git/
+**/.git/
 .github/
+**/.github/
 
-# IDE
-.idea/
-.vscode/
+# Node and package manager
+node_modules/
+**/node_modules/
+.pnpm-store/
+**/.pnpm-store/
+.pnpm/
+**/.pnpm/
+.yarn/
+**/.yarn/
+pnpm-lock.yaml
+**/pnpm-lock.yaml
+package-lock.json
+**/package-lock.json
+yarn.lock
+**/yarn.lock
 
-# Generated artifacts
+# Build outputs and generated artifacts
 dist/
-coverage/
-.turbo/
+**/dist/
+dist-ssr/
+**/dist-ssr/
+build/
+**/build/
+out/
+**/out/
+.next/
+**/.next/
+.vite/
+**/.vite/
 .parcel-cache/
+**/.parcel-cache/
+.cache/
+**/.cache/
+.turbo/
+**/.turbo/
+.vercel/
+**/.vercel/
+.run/
+**/.run/
+coverage/
+**/coverage/
+*.tsbuildinfo
 **/*.tsbuildinfo
-eeg-demo/pkg/
-packages/*/pkg/
-packages/*/demo/pkg/
+public/pkg/
+**/public/pkg/
+pkg/
+**/pkg/
+target/
+**/target/
+*.wasm
+**/*.wasm
 
-# Build outputs
-android-demo/.gradle/
-android-demo/build/
-ios-demo/*.xcframework/
+# IDE and editor
+.vscode/
+**/.vscode/
+!.vscode/extensions.json
+.idea/
+**/.idea/
+*.sublime-*
+**/*.sublime-*
+.DS_Store
+**/.DS_Store
+Thumbs.db
+**/Thumbs.db
 
-# Caches and temp
+# Environment
 .env
-brainflow/
-TradeLock/
-my-app/
+**/.env
+.env.*
+**/.env.*
+!.env.example
+**/.env.example
+env.manifest
+**/env.manifest
 
-# Local package locks (packages have their own)
-packages/*/pnpm-lock.yaml
-packages/*/templates/**/pnpm-lock.yaml
+# Logs and temp
+logs/
+**/logs/
+*.log
+**/*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.pid
+**/*.pid
+*.pid.lock
+**/*.pid.lock
+pids/
+**/pids/
+.tmp/
+**/.tmp/
+temp/
+**/temp/
+
+# Test and generated files
+test-results/
+**/test-results/
+junit.xml
+**/junit.xml
+*.generated.*
+**/*.generated.*
+*.min.*
+**/*.min.*
+*.map
+**/*.map

--- a/packages/rppg-web/src/__tests__/faceMeshAlignment.test.ts
+++ b/packages/rppg-web/src/__tests__/faceMeshAlignment.test.ts
@@ -1,0 +1,111 @@
+import {
+	computeFaceMeshAlignment,
+	FACE_MESH_LANDMARK_LEFT_TRAGUS,
+	FACE_MESH_LANDMARK_NOSE_TIP,
+	FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+} from "../faceMeshAlignment";
+
+function lm(
+	index: number,
+	x: number,
+	y: number,
+): NonNullable<Parameters<typeof computeFaceMeshAlignment>[0]>[number] {
+	return { x, y };
+}
+
+describe("computeFaceMeshAlignment", () => {
+	test("returns null without tragion / nose landmarks", () => {
+		expect(computeFaceMeshAlignment([], 640, 480)).toBeNull();
+		expect(computeFaceMeshAlignment([lm(0, 0.5, 0.5)], 640, 480)).toBeNull();
+	});
+
+	test("detects face too small (move closer)", () => {
+		const landmarks = [];
+		landmarks[FACE_MESH_LANDMARK_LEFT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_LEFT_TRAGUS,
+			0.46,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_RIGHT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+			0.5,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_NOSE_TIP] = lm(FACE_MESH_LANDMARK_NOSE_TIP, 0.48, 0.45);
+		const r = computeFaceMeshAlignment(landmarks, 100, 100);
+		expect(r?.aligned).toBe(false);
+		expect(r?.guidance?.code).toBe("face_move_closer");
+	});
+
+	test("detects face too large (move back)", () => {
+		const landmarks = [];
+		landmarks[FACE_MESH_LANDMARK_LEFT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_LEFT_TRAGUS,
+			0.05,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_RIGHT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+			0.85,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_NOSE_TIP] = lm(FACE_MESH_LANDMARK_NOSE_TIP, 0.45, 0.45);
+		const r = computeFaceMeshAlignment(landmarks, 100, 100);
+		expect(r?.aligned).toBe(false);
+		expect(r?.guidance?.code).toBe("face_move_back");
+	});
+
+	test("detects nose too high (lower head)", () => {
+		const landmarks = [];
+		landmarks[FACE_MESH_LANDMARK_LEFT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_LEFT_TRAGUS,
+			0.35,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_RIGHT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+			0.55,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_NOSE_TIP] = lm(FACE_MESH_LANDMARK_NOSE_TIP, 0.45, 0.15);
+		const r = computeFaceMeshAlignment(landmarks, 100, 100);
+		expect(r?.aligned).toBe(false);
+		expect(r?.guidance?.code).toBe("face_lower_head");
+	});
+
+	test("detects nose too low (raise head)", () => {
+		const landmarks = [];
+		landmarks[FACE_MESH_LANDMARK_LEFT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_LEFT_TRAGUS,
+			0.35,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_RIGHT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+			0.55,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_NOSE_TIP] = lm(FACE_MESH_LANDMARK_NOSE_TIP, 0.45, 0.72);
+		const r = computeFaceMeshAlignment(landmarks, 100, 100);
+		expect(r?.aligned).toBe(false);
+		expect(r?.guidance?.code).toBe("face_raise_head");
+	});
+
+	test("reports aligned when geometry is in range", () => {
+		const landmarks = [];
+		landmarks[FACE_MESH_LANDMARK_LEFT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_LEFT_TRAGUS,
+			0.35,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_RIGHT_TRAGUS] = lm(
+			FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+			0.55,
+			0.45,
+		);
+		landmarks[FACE_MESH_LANDMARK_NOSE_TIP] = lm(FACE_MESH_LANDMARK_NOSE_TIP, 0.45, 0.42);
+		const r = computeFaceMeshAlignment(landmarks, 100, 100);
+		expect(r?.aligned).toBe(true);
+		expect(r?.guidance).toBeNull();
+	});
+});

--- a/packages/rppg-web/src/__tests__/managedRppgSession.test.ts
+++ b/packages/rppg-web/src/__tests__/managedRppgSession.test.ts
@@ -8,6 +8,7 @@ import type {
 } from '../rppgSession';
 
 function createDiagnostics(overrides: Partial<RppgSessionDiagnostics> = {}): RppgSessionDiagnostics {
+  const { lastFaceMeshAlignment, ...rest } = overrides;
   return {
     backendMode: 'wasm',
     estimationAvailable: true,
@@ -46,7 +47,8 @@ function createDiagnostics(overrides: Partial<RppgSessionDiagnostics> = {}): Rpp
     lastMotion: 0.02,
     lastProcessorMethod: 'rgb_meta',
     lastRoiSource: 'fallback_roi',
-    ...overrides,
+    ...rest,
+    lastFaceMeshAlignment: lastFaceMeshAlignment ?? null,
   };
 }
 

--- a/packages/rppg-web/src/__tests__/rppgAppAdapter.test.ts
+++ b/packages/rppg-web/src/__tests__/rppgAppAdapter.test.ts
@@ -52,6 +52,7 @@ function createDiagnostics(
 		lastMotion: 0.01,
 		lastProcessorMethod: "rgb_meta",
 		lastRoiSource: "fallback_roi",
+		lastFaceMeshAlignment: null,
 		...overrides,
 	};
 }
@@ -103,6 +104,57 @@ function createSource(
 }
 
 describe("RppgAppAdapter", () => {
+	test("shows TradeLock-style stabilizing copy during early capture frames", () => {
+		const adapter = createRppgAppAdapter({ nowMs: () => 1000 });
+		const snapshot = adapter.getSnapshot(
+			createSource({
+				getDiagnostics: () =>
+					createDiagnostics({
+						lastRoiSource: "multi_roi",
+						framesSeen: 12,
+					}),
+				getMetrics: () => ({
+					bpm: null,
+					confidence: 0,
+					signal_quality: 0.8,
+					calibration_trained: false,
+					skin_ratio_mean: 0.4,
+					motion_mean: 0.01,
+				}),
+			}),
+		);
+
+		expect(snapshot.status).toBe("running");
+		expect(snapshot.guidance.code).toBe("stabilizing_warmup");
+		expect(snapshot.message).toBe("Stabilizing...");
+	});
+
+	test("prefers detailed face alignment guidance when Face Mesh reports misalignment", () => {
+		const adapter = createRppgAppAdapter({ nowMs: () => 1000 });
+		const snapshot = adapter.getSnapshot(
+			createSource({
+				getDiagnostics: () =>
+					createDiagnostics({
+						faceTrackingMode: "face_mesh",
+						lastRoiSource: "multi_roi",
+						lastFaceMeshAlignment: {
+							aligned: false,
+							faceWidthRatio: 0.07,
+							noseY: 0.45,
+							guidance: {
+								code: "face_move_closer",
+								message: "Move Closer",
+							},
+						},
+					}),
+			}),
+		);
+
+		expect(snapshot.status).toBe("ready");
+		expect(snapshot.guidance.code).toBe("face_move_closer");
+		expect(snapshot.message).toBe("Move Closer");
+	});
+
 	test("derives a ready app snapshot from a healthy running session", () => {
 		const adapter = createRppgAppAdapter({ nowMs: () => 1000 });
 		const snapshot = adapter.getSnapshot(createSource());
@@ -112,7 +164,7 @@ describe("RppgAppAdapter", () => {
 		expect(snapshot.canPublish).toBe(true);
 		expect(snapshot.publishBpm).toBe(72);
 		expect(snapshot.guidance.code).toBe("active_monitoring");
-		expect(snapshot.message).toBe("Active monitoring");
+		expect(snapshot.message).toBe("Active Monitoring");
 		expect(snapshot.debug.estimationAvailable).toBe(true);
 	});
 

--- a/packages/rppg-web/src/__tests__/rppgGating.test.ts
+++ b/packages/rppg-web/src/__tests__/rppgGating.test.ts
@@ -135,5 +135,53 @@ describe("RppgGatingController", () => {
 		expect(lowLight.state).toBe("needs_light");
 		expect(lowLight.guidance.code).toBe("increase_lighting");
 	});
+
+	test("surfaces face mesh alignment guidance without changing BPM state", () => {
+		const gate = new RppgGatingController({});
+		const misaligned = gate.update({
+			nowMs: 0,
+			hasFace: true,
+			faceMeshAlignment: {
+				aligned: false,
+				faceWidthRatio: 0.08,
+				noseY: 0.4,
+				guidance: {
+					code: "face_move_closer",
+					message: "Move Closer",
+				},
+			},
+			metrics: {
+				bpm: 72,
+				confidence: 0.7,
+				signal_quality: 0.6,
+				skin_ratio_mean: 0.3,
+				motion_mean: 0.02,
+				baseline_bpm: 70,
+			},
+		});
+		expect(misaligned.faceAlignmentGuidance?.code).toBe("face_move_closer");
+		expect(misaligned.state).toBe("active");
+		expect(misaligned.publishBpm).toBe(72);
+
+		const aligned = gate.update({
+			nowMs: 100,
+			hasFace: true,
+			faceMeshAlignment: {
+				aligned: true,
+				faceWidthRatio: 0.35,
+				noseY: 0.42,
+				guidance: null,
+			},
+			metrics: {
+				bpm: 72,
+				confidence: 0.7,
+				signal_quality: 0.6,
+				skin_ratio_mean: 0.3,
+				motion_mean: 0.02,
+				baseline_bpm: 70,
+			},
+		});
+		expect(aligned.faceAlignmentGuidance).toBeNull();
+	});
 });
 

--- a/packages/rppg-web/src/__tests__/rppgSession.test.ts
+++ b/packages/rppg-web/src/__tests__/rppgSession.test.ts
@@ -33,6 +33,7 @@ function createRunnerStub(diagnostics: Partial<DemoRunnerDiagnostics> = {}) {
     lastMotion: null,
     lastProcessorMethod: null,
     lastRoiSource: null,
+    lastFaceMeshAlignment: null,
   };
   return {
     start: jest.fn(async () => {}),

--- a/packages/rppg-web/src/demoRunner.ts
+++ b/packages/rppg-web/src/demoRunner.ts
@@ -1,3 +1,4 @@
+import type { FaceMeshAlignmentSnapshot } from "./faceMeshAlignment";
 import {
 	FrameSource,
 	Frame,
@@ -49,6 +50,8 @@ export type DemoRunnerDiagnostics = {
 	lastMotion: number | null;
 	lastProcessorMethod: "rgb_meta" | "rgb" | "intensity" | null;
 	lastRoiSource: "multi_roi" | "face_roi" | "fallback_roi" | null;
+	/** Latest Face Mesh framing snapshot from {@link Frame.faceMeshAlignment}, when present. */
+	lastFaceMeshAlignment: FaceMeshAlignmentSnapshot | null;
 };
 
 export type DemoRunnerError = {
@@ -85,6 +88,7 @@ export class DemoRunner {
 		lastMotion: null,
 		lastProcessorMethod: null,
 		lastRoiSource: null,
+		lastFaceMeshAlignment: null,
 	};
 	private lastError: DemoRunnerError | null = null;
 
@@ -116,6 +120,7 @@ export class DemoRunner {
 
 	private onFrame(frame: Frame) {
 		if (!this.running) return;
+		this.diagnostics.lastFaceMeshAlignment = frame.faceMeshAlignment ?? null;
 		this.diagnostics.framesSeen += 1;
 		const now =
 			typeof performance !== "undefined" ? performance.now() : Date.now();

--- a/packages/rppg-web/src/faceMeshAlignment.ts
+++ b/packages/rppg-web/src/faceMeshAlignment.ts
@@ -1,0 +1,106 @@
+/** Guidance codes produced only from face-mesh geometry (see {@link computeFaceMeshAlignment}). */
+export type FaceMeshAlignmentGuidanceCode =
+	| "face_move_closer"
+	| "face_move_back"
+	| "face_lower_head"
+	| "face_raise_head";
+
+/** MediaPipe Face Mesh landmark indices (canonical topology). */
+export const FACE_MESH_LANDMARK_LEFT_TRAGUS = 234;
+export const FACE_MESH_LANDMARK_RIGHT_TRAGUS = 454;
+export const FACE_MESH_LANDMARK_NOSE_TIP = 1;
+
+export type FaceMeshLandmark = { x?: number; y?: number };
+
+export type FaceMeshAlignmentOptions = {
+	/** Face width (ear–ear) / frame width; below → move closer. Default 0.15 (TradeLock). */
+	minFaceWidthRatio?: number;
+	/** Above → move back. Default 0.6 (TradeLock). */
+	maxFaceWidthRatio?: number;
+	/** Nose tip normalized Y; above → lower head. Default 0.22 (TradeLock). */
+	noseYUpperBound?: number;
+	/** Below → raise head. Default 0.58 (TradeLock). */
+	noseYLowerBound?: number;
+};
+
+export type FaceMeshAlignmentSnapshot = {
+	aligned: boolean;
+	faceWidthRatio: number;
+	noseY: number;
+	/** Set when `aligned` is false. */
+	guidance: { code: FaceMeshAlignmentGuidanceCode; message: string } | null;
+};
+
+const defaultOpts: Required<FaceMeshAlignmentOptions> = {
+	minFaceWidthRatio: 0.15,
+	maxFaceWidthRatio: 0.6,
+	noseYUpperBound: 0.22,
+	noseYLowerBound: 0.58,
+};
+
+/**
+ * Geometry hints for MediaPipe Face Mesh landmarks (normalized [0,1] coords).
+ * Distance uses left/right tragion; vertical uses nose tip.
+ */
+export function computeFaceMeshAlignment(
+	landmarks: readonly FaceMeshLandmark[],
+	frameWidth: number,
+	frameHeight: number,
+	options: FaceMeshAlignmentOptions = {},
+): FaceMeshAlignmentSnapshot | null {
+	if (
+		!landmarks?.length ||
+		frameWidth <= 0 ||
+		frameHeight <= 0 ||
+		!Number.isFinite(frameWidth) ||
+		!Number.isFinite(frameHeight)
+	) {
+		return null;
+	}
+	const left = landmarks[FACE_MESH_LANDMARK_LEFT_TRAGUS];
+	const right = landmarks[FACE_MESH_LANDMARK_RIGHT_TRAGUS];
+	const nose = landmarks[FACE_MESH_LANDMARK_NOSE_TIP];
+	if (!left || !right || !nose) return null;
+
+	const lx = Number(left.x ?? NaN);
+	const rx = Number(right.x ?? NaN);
+	const noseY = Number(nose.y ?? NaN);
+	if (!Number.isFinite(lx) || !Number.isFinite(rx) || !Number.isFinite(noseY)) {
+		return null;
+	}
+
+	const o = { ...defaultOpts, ...options };
+	const faceWidthPx = Math.abs(rx - lx) * frameWidth;
+	const faceWidthRatio = faceWidthPx / frameWidth;
+
+	let guidance: FaceMeshAlignmentSnapshot["guidance"] = null;
+
+	if (faceWidthRatio < o.minFaceWidthRatio) {
+		guidance = {
+			code: "face_move_closer",
+			message: "Move Closer",
+		};
+	} else if (faceWidthRatio > o.maxFaceWidthRatio) {
+		guidance = {
+			code: "face_move_back",
+			message: "Move Back",
+		};
+	} else if (noseY < o.noseYUpperBound) {
+		guidance = {
+			code: "face_lower_head",
+			message: "Lower your head slightly",
+		};
+	} else if (noseY > o.noseYLowerBound) {
+		guidance = {
+			code: "face_raise_head",
+			message: "Raise your head slightly",
+		};
+	}
+
+	return {
+		aligned: guidance == null,
+		faceWidthRatio,
+		noseY,
+		guidance,
+	};
+}

--- a/packages/rppg-web/src/frameSource.ts
+++ b/packages/rppg-web/src/frameSource.ts
@@ -1,3 +1,5 @@
+import type { FaceMeshAlignmentSnapshot } from "./faceMeshAlignment";
+
 export type ROI = { x: number; y: number; w: number; h: number };
 
 export type Frame = {
@@ -8,6 +10,8 @@ export type Frame = {
 	roi?: ROI;
 	rois?: ROI[];
 	timestampMs?: number;
+	/** Populated by {@link MediaPipeFaceFrameSource} when Face Mesh landmarks are available. */
+	faceMeshAlignment?: FaceMeshAlignmentSnapshot | null;
 };
 
 export interface FrameSource {

--- a/packages/rppg-web/src/index.ts
+++ b/packages/rppg-web/src/index.ts
@@ -44,6 +44,18 @@ export { MediaPipeFaceFrameSource } from "./mediaPipeFaceFrameSource";
 export { loadFaceMesh } from "./mediapipeLoader";
 export { averageGreenInROI } from "./frameSource";
 export type { FrameSource, Frame, ROI } from "./frameSource";
+export {
+	computeFaceMeshAlignment,
+	FACE_MESH_LANDMARK_LEFT_TRAGUS,
+	FACE_MESH_LANDMARK_RIGHT_TRAGUS,
+	FACE_MESH_LANDMARK_NOSE_TIP,
+} from "./faceMeshAlignment";
+export type {
+	FaceMeshAlignmentGuidanceCode,
+	FaceMeshAlignmentOptions,
+	FaceMeshAlignmentSnapshot,
+	FaceMeshLandmark,
+} from "./faceMeshAlignment";
 export { loadWasmBackend } from "./wasmBackend";
 export { createUnavailableBackend } from "./wasmBackend";
 export type { LoadWasmBackendOptions, WasmImporter } from "./wasmBackend";
@@ -89,6 +101,7 @@ export type {
 export {
 	createRppgAppAdapter,
 	createRppgAppMonitor,
+	RPPG_GUIDANCE_WARMUP_FRAME_COUNT,
 	RppgAppAdapter,
 	RppgAppMonitor,
 } from "./rppgAppAdapter";

--- a/packages/rppg-web/src/mediaPipeFaceFrameSource.ts
+++ b/packages/rppg-web/src/mediaPipeFaceFrameSource.ts
@@ -1,3 +1,4 @@
+import { computeFaceMeshAlignment } from "./faceMeshAlignment";
 import {
 	FrameSource,
 	Frame,
@@ -133,6 +134,13 @@ export class MediaPipeFaceFrameSource implements FrameSource {
 				const roi = this.smoothRoi(raw, frame.width, frame.height);
 				frame.roi = roi;
 				frame.rois = this.subRoisFromFace(roi);
+				frame.faceMeshAlignment = computeFaceMeshAlignment(
+					landmarks,
+					frame.width,
+					frame.height,
+				);
+			} else {
+				frame.faceMeshAlignment = null;
 			}
 			if (this.onFrame) this.onFrame(frame);
 		} catch (error) {

--- a/packages/rppg-web/src/rppgAppAdapter.ts
+++ b/packages/rppg-web/src/rppgAppAdapter.ts
@@ -38,7 +38,16 @@ export type RppgAppGuidanceCode =
 	| RppgGatingOutput["guidance"]["code"]
 	| "starting"
 	| "retrying"
-	| "stopped";
+	| "stopped"
+	| "stabilizing_warmup";
+
+/**
+ * First N frames match TradeLock: show {@link STABILIZING_WARMUP_MESSAGE} before
+ * gating copy from pulse estimation (their `frameCount > 45` gate).
+ */
+export const RPPG_GUIDANCE_WARMUP_FRAME_COUNT = 46;
+
+const STABILIZING_WARMUP_MESSAGE = "Stabilizing...";
 
 export type RppgAppGuidance = {
 	code: RppgAppGuidanceCode;
@@ -111,6 +120,7 @@ function idleGating(message: string): RppgGatingOutput {
 			code: "idle",
 			message,
 		},
+		faceAlignmentGuidance: null,
 		publishBpm: null,
 		holding: false,
 		debug: {
@@ -193,13 +203,40 @@ function deriveGuidance(
 		};
 	}
 
+	const alignment = gating.faceAlignmentGuidance;
+	if (
+		alignment &&
+		(status === "running" || status === "ready" || status === "degraded") &&
+		!(
+			status === "degraded" &&
+			diagnostics?.state.reason === "backend_unavailable"
+		)
+	) {
+		return { code: alignment.code, message: alignment.message };
+	}
+
+	const framesSeen = diagnostics?.framesSeen ?? RPPG_GUIDANCE_WARMUP_FRAME_COUNT;
+	if (
+		status === "running" &&
+		!gating.faceAlignmentGuidance &&
+		framesSeen < RPPG_GUIDANCE_WARMUP_FRAME_COUNT &&
+		gating.guidance.code !== "no_face" &&
+		gating.guidance.code !== "increase_lighting" &&
+		gating.guidance.code !== "motion_hold"
+	) {
+		return {
+			code: "stabilizing_warmup",
+			message: STABILIZING_WARMUP_MESSAGE,
+		};
+	}
+
 	switch (status) {
 		case "idle":
 			return { code: "idle", message: "Ready to start monitoring" };
 		case "starting":
 			return {
 				code: "starting",
-				message: "Initializing camera and rPPG pipeline",
+				message: "Initializing...",
 			};
 		case "retrying":
 			return {
@@ -264,6 +301,7 @@ export class RppgAppAdapter {
 					nowMs,
 					metrics,
 					hasFace: inferHasFace(diagnostics),
+					faceMeshAlignment: diagnostics?.lastFaceMeshAlignment ?? null,
 			  })
 			: (this.gating.reset(), idleGating("Monitoring paused"));
 		const status = deriveStatus(managedState, sessionState, normalizedError, gating);

--- a/packages/rppg-web/src/rppgGating.ts
+++ b/packages/rppg-web/src/rppgGating.ts
@@ -1,3 +1,5 @@
+import type { FaceMeshAlignmentSnapshot } from "./faceMeshAlignment";
+
 export type RppgGuidanceCode =
 	| "idle"
 	| "no_face"
@@ -5,7 +7,11 @@ export type RppgGuidanceCode =
 	| "finding_pulse"
 	| "calibrating"
 	| "active_monitoring"
-	| "motion_hold";
+	| "motion_hold"
+	| "face_move_closer"
+	| "face_move_back"
+	| "face_lower_head"
+	| "face_raise_head";
 
 export type RppgGatingState =
 	| "idle"
@@ -34,6 +40,11 @@ export type RppgGatingInputs = {
 	 * MediaPipe FaceMesh), pass it here to improve guidance accuracy.
 	 */
 	hasFace?: boolean;
+	/**
+	 * Face Mesh landmark geometry from the latest frame (e.g. {@link Frame.faceMeshAlignment}).
+	 * When present and not aligned, UI layers typically prefer this over generic gating text.
+	 */
+	faceMeshAlignment?: FaceMeshAlignmentSnapshot | null;
 };
 
 export type RppgGatingOptions = {
@@ -59,6 +70,11 @@ export type RppgGatingOptions = {
 export type RppgGatingOutput = {
 	state: RppgGatingState;
 	guidance: { code: RppgGuidanceCode; message: string };
+	/**
+	 * MediaPipe-style framing hints when the face is visible but poorly framed.
+	 * Does not change BPM gating; {@link RppgAppAdapter} promotes this for display when set.
+	 */
+	faceAlignmentGuidance: { code: RppgGuidanceCode; message: string } | null;
 	/** BPM that should be shown/used by the host app after gating. */
 	publishBpm: number | null;
 	/** True if we are currently holding a prior BPM due to motion. */
@@ -77,17 +93,23 @@ const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
 function pickGuidance(state: RppgGatingState): RppgGatingOutput["guidance"] {
 	switch (state) {
 		case "needs_face":
-			return { code: "no_face", message: "Position your face in frame" };
+			return {
+				code: "no_face",
+				message: "Return to frame — face not visible",
+			};
 		case "needs_light":
-			return { code: "increase_lighting", message: "Increase lighting" };
+			return { code: "increase_lighting", message: "Increase Lighting" };
 		case "finding_pulse":
-			return { code: "finding_pulse", message: "Hold still — finding pulse" };
+			return {
+				code: "finding_pulse",
+				message: "Hold Still - Finding Pulse",
+			};
 		case "calibrating":
-			return { code: "calibrating", message: "Calibrating…" };
+			return { code: "calibrating", message: "Calibrating..." };
 		case "motion_hold":
-			return { code: "motion_hold", message: "Hold still — stabilizing" };
+			return { code: "motion_hold", message: "Hold Still - stabilizing" };
 		case "active":
-			return { code: "active_monitoring", message: "Active monitoring" };
+			return { code: "active_monitoring", message: "Active Monitoring" };
 		default:
 			return { code: "idle", message: "Idle" };
 	}
@@ -221,9 +243,21 @@ export class RppgGatingController {
 
 		const guidance = pickGuidance(state);
 
+		const faceAlignmentGuidance =
+			hasFace &&
+			input.faceMeshAlignment &&
+			!input.faceMeshAlignment.aligned &&
+			input.faceMeshAlignment.guidance
+				? {
+						code: input.faceMeshAlignment.guidance.code,
+						message: input.faceMeshAlignment.guidance.message,
+					}
+				: null;
+
 		return {
 			state,
 			guidance,
+			faceAlignmentGuidance,
 			publishBpm,
 			holding,
 			debug: {


### PR DESCRIPTION
## Summary
- Adds MediaPipe Face Mesh landmark-based framing hints (move closer/back, head tilt) in `rppg-web`, threaded through frames, diagnostics, and `createRppgAppAdapter()`.
- Aligns gating / adapter user-facing copy with TradeLock (including early-session `Stabilizing...`).
- Updates `elata-docs` submodule pointer and `.cursorignore`.

## Testing
- `pnpm test` / `pnpm run build` in `packages/rppg-web` (run locally on branch).