### PR TITLE
fix(rppg-web): prefer now over mediaTime for live stream timestamps

### DIFF
--- a/packages/rppg-web/src/__tests__/mediaPipeFaceFrameSource.test.ts
+++ b/packages/rppg-web/src/__tests__/mediaPipeFaceFrameSource.test.ts
@@ -192,6 +192,48 @@ describe('MediaPipeFaceFrameSource edge cases', () => {
     restore();
   });
 
+  test('uses now when mediaTime is 0 (live stream)', async () => {
+    const restore = setupCanvasMock(200, 100);
+    const video = new FakeVideo(200, 100) as unknown as HTMLVideoElement;
+    let vfcCb: any = null;
+    (video as any).requestVideoFrameCallback = jest.fn((cb: any) => { vfcCb = cb; return 1; });
+    (video as any).cancelVideoFrameCallback = jest.fn();
+
+    const faceMesh = { set onResults(_cb: any) {}, send: jest.fn() };
+    const src = new MediaPipeFaceFrameSource(video, faceMesh as any, 30);
+    const frames: Frame[] = [];
+    src.onFrame = (f) => frames.push(f);
+    await src.start();
+
+    vfcCb(12345, { mediaTime: 0 });
+
+    await src.stop();
+    expect(frames.length).toBe(1);
+    expect(frames[0].timestampMs).toBe(12345);
+    restore();
+  });
+
+  test('uses mediaTime when non-zero (video file playback)', async () => {
+    const restore = setupCanvasMock(200, 100);
+    const video = new FakeVideo(200, 100) as unknown as HTMLVideoElement;
+    let vfcCb: any = null;
+    (video as any).requestVideoFrameCallback = jest.fn((cb: any) => { vfcCb = cb; return 1; });
+    (video as any).cancelVideoFrameCallback = jest.fn();
+
+    const faceMesh = { set onResults(_cb: any) {}, send: jest.fn() };
+    const src = new MediaPipeFaceFrameSource(video, faceMesh as any, 30);
+    const frames: Frame[] = [];
+    src.onFrame = (f) => frames.push(f);
+    await src.start();
+
+    vfcCb(99999, { mediaTime: 2.0 });
+
+    await src.stop();
+    expect(frames.length).toBe(1);
+    expect(frames[0].timestampMs).toBe(2000);
+    restore();
+  });
+
   test('uses requestVideoFrameCallback when available', async () => {
     const restore = setupCanvasMock(200, 100);
     const video = new FakeVideo(200, 100) as unknown as HTMLVideoElement;

--- a/packages/rppg-web/src/__tests__/mediaPipeFrameSource.test.ts
+++ b/packages/rppg-web/src/__tests__/mediaPipeFrameSource.test.ts
@@ -85,6 +85,54 @@ describe('MediaPipeFrameSource', () => {
     );
   });
 
+  test('uses now when mediaTime is 0 (live stream)', async () => {
+    const createdCanvas = new FakeCanvas(2, 1);
+    document.createElement = (tagName: string) => {
+      if (tagName === 'canvas') return createdCanvas as unknown as HTMLCanvasElement;
+      return origCreateCanvas(tagName);
+    };
+
+    const video = new FakeVideo(2, 1) as unknown as HTMLVideoElement;
+    let vfcCb: any = null;
+    (video as any).requestVideoFrameCallback = jest.fn((cb: any) => { vfcCb = cb; return 1; });
+    (video as any).cancelVideoFrameCallback = jest.fn();
+
+    const src = new MediaPipeFrameSource(video, { fps: 60 });
+    const frames: Frame[] = [];
+    src.onFrame = (f) => frames.push(f);
+    await src.start();
+
+    vfcCb(12345, { mediaTime: 0 });
+
+    await src.stop();
+    expect(frames.length).toBe(1);
+    expect(frames[0].timestampMs).toBe(12345);
+  });
+
+  test('uses mediaTime when non-zero (video file playback)', async () => {
+    const createdCanvas = new FakeCanvas(2, 1);
+    document.createElement = (tagName: string) => {
+      if (tagName === 'canvas') return createdCanvas as unknown as HTMLCanvasElement;
+      return origCreateCanvas(tagName);
+    };
+
+    const video = new FakeVideo(2, 1) as unknown as HTMLVideoElement;
+    let vfcCb: any = null;
+    (video as any).requestVideoFrameCallback = jest.fn((cb: any) => { vfcCb = cb; return 1; });
+    (video as any).cancelVideoFrameCallback = jest.fn();
+
+    const src = new MediaPipeFrameSource(video, { fps: 60 });
+    const frames: Frame[] = [];
+    src.onFrame = (f) => frames.push(f);
+    await src.start();
+
+    vfcCb(99999, { mediaTime: 1.5 });
+
+    await src.stop();
+    expect(frames.length).toBe(1);
+    expect(frames[0].timestampMs).toBe(1500);
+  });
+
   test('emits capture errors instead of swallowing them silently', async () => {
     class ThrowingCanvas extends FakeCanvas {
       override getContext(_name: string, options?: unknown) {

--- a/packages/rppg-web/src/mediaPipeFaceFrameSource.ts
+++ b/packages/rppg-web/src/mediaPipeFaceFrameSource.ts
@@ -115,10 +115,13 @@ export class MediaPipeFaceFrameSource implements FrameSource {
 				this.canvas.width,
 				this.canvas.height,
 			);
+			// Live MediaStream sources always report mediaTime: 0; prefer now for accurate windowing.
 			const ts =
-				typeof metadata?.mediaTime === "number"
+				typeof metadata?.mediaTime === "number" && metadata.mediaTime > 0
 					? metadata.mediaTime * 1000
-					: (now ?? Date.now());
+					: typeof now === "number"
+						? now
+						: Date.now();
 			const frame: Frame = {
 				data: img.data,
 				width: this.canvas.width,

--- a/packages/rppg-web/src/mediaPipeFrameSource.ts
+++ b/packages/rppg-web/src/mediaPipeFrameSource.ts
@@ -84,10 +84,13 @@ export class MediaPipeFrameSource implements FrameSource {
 				this.canvas.width,
 				this.canvas.height,
 			);
+			// Live MediaStream sources always report mediaTime: 0; prefer now for accurate windowing.
 			const ts =
-				typeof metadata?.mediaTime === "number"
+				typeof metadata?.mediaTime === "number" && metadata.mediaTime > 0
 					? metadata.mediaTime * 1000
-					: (now ?? Date.now());
+					: typeof now === "number"
+						? now
+						: Date.now();
 			const frame: Frame = {
 				data: img.data,
 				width: this.canvas.width,


### PR DESCRIPTION
## Summary

- `mediaTime` is always `0` for live `MediaStream` sources (webcam via `getUserMedia`), so the old code set every sample's `timestampMs` to `0`, keeping `windowDurationMs` at `0` forever and causing the processor to permanently report `insufficient_window` with `bpm: null`
- Add `&& metadata.mediaTime > 0` guard in both `MediaPipeFrameSource` and `MediaPipeFaceFrameSource` so live streams use the high-res `now` timestamp; video-file playback (non-zero `mediaTime`) is unchanged
- Add two tests per source covering the `mediaTime: 0` (live stream) and non-zero `mediaTime` (file playback) cases

Fixes #9

## Test plan

- [ ] `pnpm test` — 205 tests, all pass
- [ ] `pnpm build` — clean TypeScript compile
- [ ] Manual: webcam rPPG session should now accumulate `windowDurationMs` and produce BPM estimates after ~3 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)