### PR TITLE
feat(app-metrics): per-user metrics storage for sandboxed apps

### DIFF
--- a/packages/app-metrics/README.md
+++ b/packages/app-metrics/README.md
@@ -1,0 +1,39 @@
+# @elata-biosciences/app-metrics
+
+Per-user metrics storage for sandboxed apps in the Elata appstore.
+
+The package ships two entry points:
+
+- **`@elata-biosciences/app-metrics`** — `createMetricsClient()` for apps running inside the sandboxed iframe.
+- **`@elata-biosciences/app-metrics/host`** — `createMetricsHost()` for the appstore shell.
+
+The host owns storage; the app talks to the host over a transferred `MessagePort`. Data is namespaced per `(walletAddress, appId)` and never crosses app boundaries.
+
+See `docs/STORAGE_PLAN.md` and `docs/STORAGE_SCORES_PLAN.md` in the appstore repo for the full design.
+
+## App-side usage
+
+```ts
+import { createMetricsClient } from "@elata-biosciences/app-metrics";
+
+const metrics = createMetricsClient();
+
+await metrics.record({ type: "level_complete", data: { level: 3, time: 42 } });
+await metrics.saveScore({ value: 1200, meta: { level: 3 } });
+
+const top = await metrics.loadScores({ order: "value_desc", limit: 10 });
+```
+
+## Host-side usage (appstore)
+
+```ts
+import { createMetricsHost, createIndexedDbAdapter } from "@elata-biosciences/app-metrics/host";
+
+const host = createMetricsHost({
+  iframe,
+  appId,
+  walletAddress,
+  storage: createIndexedDbAdapter(),
+});
+host.start();
+```

--- a/packages/app-metrics/jest.config.cjs
+++ b/packages/app-metrics/jest.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+	transform: {
+		"^.+\\.tsx?$": ["ts-jest", { diagnostics: false }],
+	},
+	testEnvironment: "jsdom",
+	setupFiles: ["<rootDir>/jest.setup.cjs"],
+	testMatch: ["**/__tests__/**/*.test.ts"],
+	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	collectCoverage: true,
+	collectCoverageFrom: ["src/**/*.ts"],
+	coverageDirectory: "coverage",
+};

--- a/packages/app-metrics/jest.setup.cjs
+++ b/packages/app-metrics/jest.setup.cjs
@@ -1,0 +1,28 @@
+// jsdom does not implement MessageChannel/MessagePort. Provide Node's
+// worker_threads implementation, which is spec-compatible for our usage
+// (onmessage, postMessage, start, close, transferring via structuredClone).
+const { MessageChannel, MessagePort } = require("node:worker_threads");
+
+if (typeof globalThis.MessageChannel === "undefined") {
+	globalThis.MessageChannel = MessageChannel;
+}
+if (typeof globalThis.MessagePort === "undefined") {
+	globalThis.MessagePort = MessagePort;
+}
+
+// jsdom (jest env) lacks structuredClone, which fake-indexeddb requires on put.
+// Our adapter tests use plain JSON-serializable rows, so a JSON clone is
+// sufficient. Production uses the browser's native structuredClone.
+if (typeof globalThis.structuredClone === "undefined") {
+	globalThis.structuredClone = (value) => JSON.parse(JSON.stringify(value));
+}
+
+// fake-indexeddb does not auto-register in jsdom. Wire IDBFactory + IDBKeyRange
+// onto globalThis so the adapter (which uses the global IDBKeyRange) works.
+const fakeIdb = require("fake-indexeddb");
+if (typeof globalThis.IDBKeyRange === "undefined") {
+	globalThis.IDBKeyRange = fakeIdb.IDBKeyRange;
+}
+if (typeof globalThis.indexedDB === "undefined") {
+	globalThis.indexedDB = new fakeIdb.IDBFactory();
+}

--- a/packages/app-metrics/llms.txt
+++ b/packages/app-metrics/llms.txt
@@ -1,0 +1,21 @@
+# @elata-biosciences/app-metrics — context for tools and agents
+
+## Role
+Per-user metrics storage for sandboxed apps in the Elata appstore. The host (appstore shell) owns IndexedDB; the app (inside the sandboxed iframe) talks to the host over a transferred `MessagePort`. Data is namespaced per `(walletAddress, appId)` and never crosses app boundaries.
+
+Two entry points:
+- Default — `createMetricsClient()` for apps.
+- `/host` — `createMetricsHost()`, `createIndexedDbAdapter()`, `createMemoryAdapter()` for the appstore shell.
+
+## Wire protocol
+Handshake: host posts `{ kind: '__elata_metrics_init', v: 1 }` with `port2` transferred. App captures `port1`, uses it for all traffic. After handshake, origin checks no longer apply — the port is the trust boundary.
+
+Ops: `record` / `query` / `clear` / `saveScore` / `loadScores`.
+
+## Quotas
+- 5 MB per `(walletAddress, appId)`.
+- 64 KB per record (combined `value` + `meta` for scores; `data` for records).
+- 100 writes/minute per app per wallet.
+
+## Source of truth
+https://github.com/Elata-Biosciences/elata-bio-sdk/tree/main/packages/app-metrics

--- a/packages/app-metrics/package.json
+++ b/packages/app-metrics/package.json
@@ -1,0 +1,65 @@
+{
+	"name": "@elata-biosciences/app-metrics",
+	"version": "0.1.0",
+	"description": "Per-user metrics storage for sandboxed apps in the Elata appstore",
+	"license": "MIT",
+	"author": "Elata",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Elata-Biosciences/elata-bio-sdk.git",
+		"directory": "packages/app-metrics"
+	},
+	"homepage": "https://github.com/Elata-Biosciences/elata-bio-sdk#readme",
+	"bugs": "https://github.com/Elata-Biosciences/elata-bio-sdk/issues",
+	"keywords": [
+		"elata",
+		"appstore",
+		"metrics",
+		"sandbox",
+		"indexeddb"
+	],
+	"engines": {
+		"node": ">=20"
+	},
+	"type": "module",
+	"sideEffects": false,
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./host": {
+			"types": "./dist/host.d.ts",
+			"import": "./dist/host.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md",
+		"llms.txt"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"lint": "pnpm exec biome lint src jest.config.cjs",
+		"test": "jest --config ./jest.config.cjs --passWithNoTests",
+		"test:coverage": "jest --config ./jest.config.cjs --coverage --passWithNoTests",
+		"clean": "node ./scripts/clean.mjs",
+		"build": "tsc -p tsconfig.json && node ./scripts/fix-dist-import-specifiers.mjs && node ./scripts/verify-dist-esm.mjs",
+		"verify:build": "node ../../scripts/verify-package-build.mjs dist/index.js dist/index.d.ts && node ../../scripts/verify-package-build.mjs dist/host.js dist/host.d.ts",
+		"verify:publish": "pnpm run verify:build",
+		"prepare:publish": "pnpm run build",
+		"prepack": "pnpm run prepare:publish && pnpm run verify:publish"
+	},
+	"devDependencies": {
+		"@types/jest": "29.5.14",
+		"fake-indexeddb": "6.0.0",
+		"jest": "29.7.0",
+		"jest-environment-jsdom": "29.7.0",
+		"ts-jest": "29.4.4",
+		"typescript": "5.9.3"
+	}
+}

--- a/packages/app-metrics/scripts/clean.mjs
+++ b/packages/app-metrics/scripts/clean.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgDir = path.resolve(__dirname, "..");
+
+const dirs = ["dist", "coverage"];
+const files = ["tsconfig.tsbuildinfo"];
+
+for (const dir of dirs) {
+	const full = path.join(pkgDir, dir);
+	if (fs.existsSync(full)) {
+		fs.rmSync(full, { recursive: true, force: true });
+		console.log("Removed:", dir);
+	}
+}
+for (const file of files) {
+	const full = path.join(pkgDir, file);
+	if (fs.existsSync(full)) {
+		fs.rmSync(full, { force: true });
+		console.log("Removed:", file);
+	}
+}

--- a/packages/app-metrics/scripts/fix-dist-import-specifiers.mjs
+++ b/packages/app-metrics/scripts/fix-dist-import-specifiers.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+const distDir = path.join(packageRoot, "dist");
+
+const FILE_EXTENSIONS = new Set([".js", ".d.ts"]);
+const SPECIFIER_PATTERN =
+	/((?:import|export)\s[^'"]*?from\s*|import\s*\(\s*)["'](\.{1,2}\/[^"']+)["']/g;
+
+function shouldAppendJs(specifier) {
+	const ext = path.extname(specifier);
+	return !ext;
+}
+
+function rewriteSpecifiers(contents) {
+	return contents.replace(SPECIFIER_PATTERN, (match, prefix, specifier) => {
+		if (!shouldAppendJs(specifier)) return match;
+		const rewritten = `${specifier}.js`;
+		return `${prefix}"${rewritten}"`;
+	});
+}
+
+function rewriteFile(filePath) {
+	const original = fs.readFileSync(filePath, "utf8");
+	const rewritten = rewriteSpecifiers(original);
+	if (rewritten !== original) {
+		fs.writeFileSync(filePath, rewritten);
+	}
+}
+
+function walk(dir) {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			walk(full);
+			continue;
+		}
+		const ext = path.extname(entry.name);
+		const isDts = entry.name.endsWith(".d.ts");
+		if (FILE_EXTENSIONS.has(ext) || isDts) {
+			rewriteFile(full);
+		}
+	}
+}
+
+if (!fs.existsSync(distDir)) {
+	console.error("dist directory not found:", distDir);
+	process.exit(1);
+}
+
+walk(distDir);

--- a/packages/app-metrics/scripts/verify-dist-esm.mjs
+++ b/packages/app-metrics/scripts/verify-dist-esm.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+
+const packageRoot = process.cwd();
+const distIndex = path.join(packageRoot, "dist", "index.js");
+const distHost = path.join(packageRoot, "dist", "host.js");
+
+assert.ok(
+	fs.existsSync(distIndex),
+	"dist/index.js must exist before ESM verification",
+);
+assert.ok(
+	fs.existsSync(distHost),
+	"dist/host.js must exist before ESM verification",
+);
+
+const indexSource = fs.readFileSync(distIndex, "utf8");
+assert.match(
+	indexSource,
+	/\.\/client\.js"/,
+	"dist/index.js should re-export client using explicit .js specifier",
+);
+
+const hostSource = fs.readFileSync(distHost, "utf8");
+assert.match(
+	hostSource,
+	/\.\/protocol\.js"/,
+	"dist/host.js should reference protocol using explicit .js specifier",
+);
+
+console.log("dist ESM specifiers OK");

--- a/packages/app-metrics/src/__tests__/client.test.ts
+++ b/packages/app-metrics/src/__tests__/client.test.ts
@@ -1,0 +1,128 @@
+import { createMetricsClient } from "../client";
+import {
+	type HostResponse,
+	INIT_MESSAGE_KIND,
+	PROTOCOL_VERSION,
+} from "../protocol";
+
+/**
+ * The client listens on a Window for the init message and captures a transferred
+ * port. We simulate this by dispatching a synthetic `message` event on a fake
+ * EventTarget that satisfies the parts of `Window` the client uses.
+ */
+interface FakeWindow extends EventTarget {
+	postMessage?: (message: unknown, targetOrigin?: string) => void;
+}
+
+function makeFakeWindow(): FakeWindow {
+	const target = new EventTarget();
+	return target as FakeWindow;
+}
+
+function fireInit(win: FakeWindow, port: MessagePort) {
+	const ev = new MessageEvent("message", {
+		data: { kind: INIT_MESSAGE_KIND, v: PROTOCOL_VERSION },
+		ports: [port],
+	});
+	win.dispatchEvent(ev);
+}
+
+describe("createMetricsClient", () => {
+	test("handshake captures port and forwards calls", async () => {
+		const win = makeFakeWindow();
+		const client = createMetricsClient({ window: win as unknown as Window });
+
+		const channel = new MessageChannel();
+		const hostPort = channel.port1;
+		hostPort.onmessage = (ev) => {
+			const req = ev.data as { id: string; op: string };
+			const response: HostResponse = {
+				v: 1,
+				id: req.id,
+				ok: true,
+				result: { id: "fake", timestamp: 1 },
+			};
+			hostPort.postMessage(response);
+		};
+		hostPort.start();
+
+		fireInit(win, channel.port2);
+		await client.ready();
+		expect(client.isReady()).toBe(true);
+
+		const result = await client.saveScore({ value: 42 });
+		expect(result).toEqual({ id: "fake", timestamp: 1 });
+		client.dispose();
+	});
+
+	test("calls made before handshake queue and resolve after init", async () => {
+		const win = makeFakeWindow();
+		const client = createMetricsClient({ window: win as unknown as Window });
+
+		const channel = new MessageChannel();
+		const hostPort = channel.port1;
+		hostPort.onmessage = (ev) => {
+			const req = ev.data as { id: string };
+			hostPort.postMessage({ v: 1, id: req.id, ok: true, result: [] });
+		};
+		hostPort.start();
+
+		const queryPromise = client.query({});
+		fireInit(win, channel.port2);
+		await expect(queryPromise).resolves.toEqual([]);
+		client.dispose();
+	});
+
+	test("handshake timeout rejects pending calls", async () => {
+		jest.useFakeTimers();
+		const win = makeFakeWindow();
+		const client = createMetricsClient({
+			window: win as unknown as Window,
+			handshakeTimeoutMs: 100,
+		});
+
+		const callPromise = client.saveScore({ value: 1 });
+		jest.advanceTimersByTime(150);
+		jest.useRealTimers();
+
+		await expect(callPromise).rejects.toMatchObject({ code: "handshake_timeout" });
+		client.dispose();
+	});
+
+	test("dispose rejects pending calls", async () => {
+		const win = makeFakeWindow();
+		const client = createMetricsClient({
+			window: win as unknown as Window,
+			handshakeTimeoutMs: Number.POSITIVE_INFINITY,
+		});
+		const pending = client.saveScore({ value: 1 });
+		client.dispose();
+		await expect(pending).rejects.toMatchObject({ code: "disposed" });
+	});
+
+	test("host error surfaces with error code", async () => {
+		const win = makeFakeWindow();
+		const client = createMetricsClient({ window: win as unknown as Window });
+
+		const channel = new MessageChannel();
+		const hostPort = channel.port1;
+		hostPort.onmessage = (ev) => {
+			const req = ev.data as { id: string };
+			hostPort.postMessage({
+				v: 1,
+				id: req.id,
+				ok: false,
+				error: "quota_exceeded",
+			});
+		};
+		hostPort.start();
+
+		fireInit(win, channel.port2);
+		await client.ready();
+
+		await expect(client.saveScore({ value: 1 })).rejects.toMatchObject({
+			code: "quota_exceeded",
+		});
+		client.dispose();
+	});
+});

--- a/packages/app-metrics/src/__tests__/host.test.ts
+++ b/packages/app-metrics/src/__tests__/host.test.ts
@@ -1,0 +1,282 @@
+import { createMemoryAdapter } from "../adapters/memory";
+import {
+	createMetricsHost,
+	type MetricsHost,
+} from "../host";
+import {
+	type AppRecord,
+	type AppScore,
+	type HostResponse,
+	INIT_MESSAGE_KIND,
+	PROTOCOL_VERSION,
+} from "../protocol";
+
+interface FakeFrame {
+	contentWindow: {
+		postMessage: jest.Mock<
+			void,
+			[message: unknown, targetOrigin: string, transfer: Transferable[]]
+		>;
+	};
+}
+
+/**
+ * Set up a host wired to a freshly-allocated MessageChannel and a fake iframe.
+ * The returned `appPort` is the port the sandboxed app would receive — tests
+ * send requests through it and assert on responses.
+ */
+function setupHost(
+	overrides: Partial<{
+		walletAddress: string;
+		appId: string;
+		quotaBytes: number;
+		maxRecordBytes: number;
+		writeRateLimit: { count: number; windowMs: number };
+		now: () => number;
+		randomId: () => string;
+	}> = {},
+): { host: MetricsHost; appPort: MessagePort; storage: ReturnType<typeof createMemoryAdapter> } {
+	const storage = createMemoryAdapter();
+	const fakeFrame: FakeFrame = {
+		contentWindow: { postMessage: jest.fn() },
+	};
+	const host = createMetricsHost({
+		iframe: fakeFrame as unknown as HTMLIFrameElement,
+		appId: overrides.appId ?? "app-1",
+		walletAddress: overrides.walletAddress ?? "0xWALLET",
+		storage,
+		quotaBytes: overrides.quotaBytes,
+		maxRecordBytes: overrides.maxRecordBytes,
+		writeRateLimit: overrides.writeRateLimit,
+		now: overrides.now,
+		randomId: overrides.randomId,
+	});
+	host.start();
+	expect(fakeFrame.contentWindow.postMessage).toHaveBeenCalledTimes(1);
+	const [message, _origin, transfer] = fakeFrame.contentWindow.postMessage.mock
+		.calls[0]!;
+	expect(message).toEqual({ kind: INIT_MESSAGE_KIND, v: PROTOCOL_VERSION });
+	const appPort = transfer[0] as MessagePort;
+	appPort.start();
+	return { host, appPort, storage };
+}
+
+function call<T = unknown>(
+	port: MessagePort,
+	request: Record<string, unknown>,
+): Promise<HostResponse & { result?: T }> {
+	const id = `c_${Math.random().toString(36).slice(2)}`;
+	return new Promise((resolve) => {
+		const handler = (ev: MessageEvent<unknown>) => {
+			const data = ev.data as HostResponse;
+			if (data && data.id === id) {
+				port.removeEventListener("message", handler as EventListener);
+				resolve(data as HostResponse & { result?: T });
+			}
+		};
+		port.addEventListener("message", handler as EventListener);
+		port.postMessage({ v: PROTOCOL_VERSION, id, ...request });
+	});
+}
+
+describe("host: record / query / clear", () => {
+	test("record persists and query returns it", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			const saved = await call(appPort, {
+				op: "record",
+				type: "level_complete",
+				data: { level: 1 },
+			});
+			expect(saved.ok).toBe(true);
+
+			const queried = await call<AppRecord[]>(appPort, {
+				op: "query",
+				filter: {},
+			});
+			expect(queried.ok).toBe(true);
+			expect(queried.result).toHaveLength(1);
+			expect(queried.result?.[0]?.type).toBe("level_complete");
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("clear wipes both records and scores for the scope", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			await call(appPort, { op: "record", type: "x", data: 1 });
+			await call(appPort, { op: "saveScore", value: 10 });
+			await call(appPort, { op: "clear", scope: "app" });
+
+			const r = await call<AppRecord[]>(appPort, { op: "query", filter: {} });
+			expect(r.result).toEqual([]);
+			const s = await call<AppScore[]>(appPort, { op: "loadScores", filter: {} });
+			expect(s.result).toEqual([]);
+		} finally {
+			host.stop();
+		}
+	});
+});
+
+describe("host: saveScore", () => {
+	test("rejects NaN and Infinity", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			const nanRes = await call(appPort, { op: "saveScore", value: Number.NaN });
+			expect(nanRes.ok).toBe(false);
+			expect(nanRes.ok || (nanRes as { error: string }).error).toBe("invalid_payload");
+
+			const infRes = await call(appPort, {
+				op: "saveScore",
+				value: Number.POSITIVE_INFINITY,
+			});
+			expect(infRes.ok).toBe(false);
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("accepts negative values and zero", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			const a = await call(appPort, { op: "saveScore", value: 0 });
+			const b = await call(appPort, { op: "saveScore", value: -42 });
+			expect(a.ok).toBe(true);
+			expect(b.ok).toBe(true);
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("size accounting includes meta", async () => {
+		const { appPort, host } = setupHost({ maxRecordBytes: 64 });
+		try {
+			const tinyOk = await call(appPort, { op: "saveScore", value: 1 });
+			expect(tinyOk.ok).toBe(true);
+
+			const bigMeta = "x".repeat(100);
+			const oversize = await call(appPort, {
+				op: "saveScore",
+				value: 1,
+				meta: { s: bigMeta },
+			});
+			expect(oversize.ok).toBe(false);
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("contributes to quota with records", async () => {
+		const { appPort, host } = setupHost({ quotaBytes: 60 });
+		try {
+			const r = await call(appPort, { op: "record", type: "t", data: "x".repeat(30) });
+			expect(r.ok).toBe(true);
+			const overshoot = await call(appPort, {
+				op: "saveScore",
+				value: 1,
+				meta: { s: "x".repeat(100) },
+			});
+			expect(overshoot.ok).toBe(false);
+			expect(overshoot.ok || (overshoot as { error: string }).error).toBe(
+				"quota_exceeded",
+			);
+		} finally {
+			host.stop();
+		}
+	});
+});
+
+describe("host: loadScores", () => {
+	test("default order is value_desc", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			await call(appPort, { op: "saveScore", value: 1 });
+			await call(appPort, { op: "saveScore", value: 100 });
+			await call(appPort, { op: "saveScore", value: 50 });
+
+			const res = await call<AppScore[]>(appPort, {
+				op: "loadScores",
+				filter: {},
+			});
+			expect(res.ok).toBe(true);
+			expect(res.result?.map((s) => s.value)).toEqual([100, 50, 1]);
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("timestamp_desc returns recent first", async () => {
+		let t = 1_000;
+		const { appPort, host } = setupHost({ now: () => t });
+		try {
+			await call(appPort, { op: "saveScore", value: 10 });
+			t = 2_000;
+			await call(appPort, { op: "saveScore", value: 5 });
+			t = 3_000;
+			await call(appPort, { op: "saveScore", value: 8 });
+
+			const res = await call<AppScore[]>(appPort, {
+				op: "loadScores",
+				filter: { order: "timestamp_desc" },
+			});
+			expect(res.result?.map((s) => s.timestamp)).toEqual([3_000, 2_000, 1_000]);
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("query (records) does not include scores; loadScores does not include records", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			await call(appPort, { op: "record", type: "evt", data: 1 });
+			await call(appPort, { op: "saveScore", value: 99 });
+
+			const records = await call<AppRecord[]>(appPort, {
+				op: "query",
+				filter: {},
+			});
+			expect(records.result).toHaveLength(1);
+			expect((records.result?.[0] as AppRecord).type).toBe("evt");
+
+			const scores = await call<AppScore[]>(appPort, {
+				op: "loadScores",
+				filter: {},
+			});
+			expect(scores.result).toHaveLength(1);
+			expect((scores.result?.[0] as AppScore).value).toBe(99);
+		} finally {
+			host.stop();
+		}
+	});
+
+	test("limit caps result count", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			for (let i = 0; i < 20; i++) {
+				await call(appPort, { op: "saveScore", value: i });
+			}
+			const res = await call<AppScore[]>(appPort, {
+				op: "loadScores",
+				filter: { limit: 5 },
+			});
+			expect(res.result).toHaveLength(5);
+			expect(res.result?.[0]?.value).toBe(19);
+		} finally {
+			host.stop();
+		}
+	});
+});
+
+describe("host: invalid payload", () => {
+	test("unknown op returns invalid_payload", async () => {
+		const { appPort, host } = setupHost();
+		try {
+			const res = await call(appPort, { op: "bogus" });
+			expect(res.ok).toBe(false);
+			expect((res as { error: string }).error).toBe("invalid_payload");
+		} finally {
+			host.stop();
+		}
+	});
+});

--- a/packages/app-metrics/src/__tests__/indexeddb.test.ts
+++ b/packages/app-metrics/src/__tests__/indexeddb.test.ts
@@ -1,0 +1,116 @@
+import { IDBFactory } from "fake-indexeddb";
+import { createIndexedDbAdapter } from "../adapters/indexeddb";
+import type { StoredRecord, StoredScore } from "../protocol";
+
+function makeAdapter(name: string) {
+	return createIndexedDbAdapter({
+		indexedDB: new IDBFactory(),
+		dbName: name,
+	});
+}
+
+const WALLET = "0xWALLET";
+const APP = "app-1";
+
+function record(
+	id: string,
+	overrides: Partial<StoredRecord> = {},
+): StoredRecord {
+	return {
+		id,
+		walletAddress: WALLET,
+		appId: APP,
+		type: "evt",
+		data: { x: 1 },
+		timestamp: 1_000,
+		sizeBytes: 10,
+		...overrides,
+	};
+}
+
+function score(
+	id: string,
+	value: number,
+	overrides: Partial<StoredScore> = {},
+): StoredScore {
+	return {
+		id,
+		walletAddress: WALLET,
+		appId: APP,
+		value,
+		timestamp: 1_000,
+		sizeBytes: 10,
+		...overrides,
+	};
+}
+
+describe("indexeddb adapter: scores", () => {
+	test("queryScores returns scores in value_desc order by default", async () => {
+		const a = makeAdapter("db1");
+		await a.put(score("s1", 10));
+		await a.put(score("s2", 100));
+		await a.put(score("s3", 50));
+		const out = await a.queryScores(WALLET, APP, {});
+		expect(out.map((s) => s.value)).toEqual([100, 50, 10]);
+	});
+
+	test("queryScores does not return records (sparse value index)", async () => {
+		const a = makeAdapter("db2");
+		await a.put(record("r1"));
+		await a.put(score("s1", 7));
+		const out = await a.queryScores(WALLET, APP, {});
+		expect(out).toHaveLength(1);
+		expect(out[0]?.id).toBe("s1");
+	});
+
+	test("query returns records, not scores", async () => {
+		const a = makeAdapter("db3");
+		await a.put(record("r1", { timestamp: 1 }));
+		await a.put(score("s1", 5, { timestamp: 2 }));
+		const out = await a.query(WALLET, APP, {});
+		expect(out).toHaveLength(1);
+		expect(out[0]?.id).toBe("r1");
+	});
+
+	test("queryScores with timestamp_desc order", async () => {
+		const a = makeAdapter("db4");
+		await a.put(score("s1", 10, { timestamp: 100 }));
+		await a.put(score("s2", 5, { timestamp: 200 }));
+		await a.put(score("s3", 50, { timestamp: 50 }));
+		const out = await a.queryScores(WALLET, APP, { order: "timestamp_desc" });
+		expect(out.map((s) => s.id)).toEqual(["s2", "s1", "s3"]);
+	});
+
+	test("sumBytes accounts for both records and scores", async () => {
+		const a = makeAdapter("db5");
+		await a.put(record("r1", { sizeBytes: 30 }));
+		await a.put(score("s1", 1, { sizeBytes: 20 }));
+		expect(await a.sumBytes(WALLET, APP)).toBe(50);
+	});
+
+	test("clearScope removes both records and scores", async () => {
+		const a = makeAdapter("db6");
+		await a.put(record("r1"));
+		await a.put(score("s1", 1));
+		await a.clearScope(WALLET, APP);
+		expect(await a.query(WALLET, APP, {})).toEqual([]);
+		expect(await a.queryScores(WALLET, APP, {})).toEqual([]);
+	});
+
+	test("scope isolation: another wallet/app does not see rows", async () => {
+		const a = makeAdapter("db7");
+		await a.put(score("s1", 99));
+		expect(await a.queryScores("OTHER", APP, {})).toEqual([]);
+		expect(await a.queryScores(WALLET, "other-app", {})).toEqual([]);
+	});
+
+	test("queryScores limit caps result count", async () => {
+		const a = makeAdapter("db8");
+		for (let i = 0; i < 30; i++) {
+			await a.put(score(`s${i}`, i));
+		}
+		const out = await a.queryScores(WALLET, APP, { limit: 5 });
+		expect(out).toHaveLength(5);
+		expect(out[0]?.value).toBe(29);
+	});
+});

--- a/packages/app-metrics/src/__tests__/protocol.test.ts
+++ b/packages/app-metrics/src/__tests__/protocol.test.ts
@@ -1,0 +1,123 @@
+import {
+	isClientRequest,
+	isStoredScore,
+	isValidScoreValue,
+	isValidType,
+	PROTOCOL_VERSION,
+} from "../protocol";
+
+describe("isValidType", () => {
+	test("accepts lowercase, digits, underscore", () => {
+		expect(isValidType("level_complete")).toBe(true);
+		expect(isValidType("a")).toBe(true);
+		expect(isValidType("score_v2")).toBe(true);
+	});
+
+	test("rejects empty, uppercase, leading digit, special chars", () => {
+		expect(isValidType("")).toBe(false);
+		expect(isValidType("Level")).toBe(false);
+		expect(isValidType("1foo")).toBe(false);
+		expect(isValidType("foo-bar")).toBe(false);
+		expect(isValidType("__score__")).toBe(false);
+		expect(isValidType(42)).toBe(false);
+	});
+});
+
+describe("isValidScoreValue", () => {
+	test("accepts finite numbers including negative and zero", () => {
+		expect(isValidScoreValue(0)).toBe(true);
+		expect(isValidScoreValue(42)).toBe(true);
+		expect(isValidScoreValue(-1.5)).toBe(true);
+	});
+
+	test("rejects NaN, Infinity, non-numbers", () => {
+		expect(isValidScoreValue(Number.NaN)).toBe(false);
+		expect(isValidScoreValue(Number.POSITIVE_INFINITY)).toBe(false);
+		expect(isValidScoreValue(Number.NEGATIVE_INFINITY)).toBe(false);
+		expect(isValidScoreValue("42")).toBe(false);
+		expect(isValidScoreValue(null)).toBe(false);
+		expect(isValidScoreValue(undefined)).toBe(false);
+	});
+});
+
+describe("isClientRequest", () => {
+	const base = { v: PROTOCOL_VERSION, id: "c_1" } as const;
+
+	test("accepts well-formed record", () => {
+		expect(
+			isClientRequest({ ...base, op: "record", type: "x", data: { a: 1 } }),
+		).toBe(true);
+	});
+
+	test("accepts well-formed saveScore", () => {
+		expect(isClientRequest({ ...base, op: "saveScore", value: 100 })).toBe(true);
+		expect(
+			isClientRequest({ ...base, op: "saveScore", value: 0, meta: { level: 1 } }),
+		).toBe(true);
+	});
+
+	test("rejects saveScore with invalid value", () => {
+		expect(isClientRequest({ ...base, op: "saveScore", value: Number.NaN })).toBe(
+			false,
+		);
+		expect(isClientRequest({ ...base, op: "saveScore", value: "100" })).toBe(false);
+	});
+
+	test("accepts loadScores with filter object", () => {
+		expect(isClientRequest({ ...base, op: "loadScores", filter: {} })).toBe(true);
+		expect(
+			isClientRequest({
+				...base,
+				op: "loadScores",
+				filter: { order: "value_desc", limit: 10 },
+			}),
+		).toBe(true);
+	});
+
+	test("rejects loadScores with non-object filter", () => {
+		expect(isClientRequest({ ...base, op: "loadScores", filter: null })).toBe(
+			false,
+		);
+		expect(isClientRequest({ ...base, op: "loadScores" })).toBe(false);
+	});
+
+	test("rejects wrong protocol version", () => {
+		expect(
+			isClientRequest({ v: 2, id: "c_1", op: "record", type: "x", data: 1 }),
+		).toBe(false);
+	});
+
+	test("rejects missing id", () => {
+		expect(isClientRequest({ v: 1, op: "record", type: "x", data: 1 })).toBe(false);
+	});
+
+	test("rejects unknown op", () => {
+		expect(isClientRequest({ ...base, op: "bogus" })).toBe(false);
+	});
+});
+
+describe("isStoredScore", () => {
+	test("distinguishes scores from records by presence of numeric value", () => {
+		expect(
+			isStoredScore({
+				id: "1",
+				walletAddress: "w",
+				appId: "a",
+				value: 5,
+				timestamp: 1,
+				sizeBytes: 1,
+			}),
+		).toBe(true);
+		expect(
+			isStoredScore({
+				id: "1",
+				walletAddress: "w",
+				appId: "a",
+				type: "t",
+				data: null,
+				timestamp: 1,
+				sizeBytes: 1,
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/app-metrics/src/adapters/indexeddb.ts
+++ b/packages/app-metrics/src/adapters/indexeddb.ts
@@ -1,0 +1,213 @@
+import {
+	isStoredScore,
+	type StoredRecord,
+	type StoredScore,
+} from "../protocol";
+import type { StorageAdapter } from "./types";
+
+const DB_NAME = "elata-app-metrics";
+const STORE = "records";
+const DB_VERSION = 2;
+
+const INDEX_BY_SCOPE_TS = "by_scope_ts";
+const INDEX_BY_SCOPE_TYPE = "by_scope_type";
+const INDEX_BY_SCOPE_VALUE = "by_scope_value";
+
+export interface IndexedDbAdapterOptions {
+	indexedDB?: IDBFactory;
+	dbName?: string;
+}
+
+export function createIndexedDbAdapter(
+	options: IndexedDbAdapterOptions = {},
+): StorageAdapter {
+	const idb = options.indexedDB ?? globalThis.indexedDB;
+	const dbName = options.dbName ?? DB_NAME;
+
+	if (!idb) {
+		throw new Error(
+			"IndexedDB is not available in this environment. Provide an IDBFactory via options.indexedDB or use createMemoryAdapter().",
+		);
+	}
+
+	let dbPromise: Promise<IDBDatabase> | null = null;
+
+	const open = (): Promise<IDBDatabase> => {
+		if (dbPromise) return dbPromise;
+		dbPromise = new Promise((resolve, reject) => {
+			const req = idb.open(dbName, DB_VERSION);
+			req.onupgradeneeded = () => {
+				const db = req.result;
+				let store: IDBObjectStore;
+				if (!db.objectStoreNames.contains(STORE)) {
+					store = db.createObjectStore(STORE, { keyPath: "id" });
+					store.createIndex(INDEX_BY_SCOPE_TS, [
+						"walletAddress",
+						"appId",
+						"timestamp",
+					]);
+					store.createIndex(INDEX_BY_SCOPE_TYPE, [
+						"walletAddress",
+						"appId",
+						"type",
+					]);
+				} else {
+					const tx = req.transaction;
+					if (!tx) throw new Error("upgrade transaction missing");
+					store = tx.objectStore(STORE);
+				}
+				// v2: sparse index for scores (rows without `value` are skipped automatically).
+				if (!store.indexNames.contains(INDEX_BY_SCOPE_VALUE)) {
+					store.createIndex(INDEX_BY_SCOPE_VALUE, [
+						"walletAddress",
+						"appId",
+						"value",
+					]);
+				}
+			};
+			req.onsuccess = () => resolve(req.result);
+			req.onerror = () => reject(req.error);
+		});
+		return dbPromise;
+	};
+
+	return {
+		async put(row) {
+			const db = await open();
+			await new Promise<void>((resolve, reject) => {
+				const t = db.transaction(STORE, "readwrite");
+				const r = t.objectStore(STORE).put(row);
+				r.onsuccess = () => resolve();
+				r.onerror = () => reject(r.error);
+				t.onerror = () => reject(t.error);
+			});
+		},
+
+		async query(walletAddress, appId, filter) {
+			const db = await open();
+			const limit = clampLimit(filter.limit);
+			const since = filter.since ?? Number.NEGATIVE_INFINITY;
+			const until = filter.until ?? Number.POSITIVE_INFINITY;
+			const results: StoredRecord[] = [];
+
+			await new Promise<void>((resolve, reject) => {
+				const t = db.transaction(STORE, "readonly");
+				const store = t.objectStore(STORE);
+				const idx = store.index(INDEX_BY_SCOPE_TS);
+				const lower = [walletAddress, appId, Number.NEGATIVE_INFINITY];
+				const upper = [walletAddress, appId, Number.POSITIVE_INFINITY];
+				const range = IDBKeyRange.bound(lower, upper);
+				const req = idx.openCursor(range, "prev");
+				req.onsuccess = () => {
+					const cursor = req.result;
+					if (!cursor || results.length >= limit) {
+						resolve();
+						return;
+					}
+					const row = cursor.value as StoredRecord | StoredScore;
+					if (!isStoredScore(row)) {
+						const typeOk = filter.type === undefined || row.type === filter.type;
+						const tsOk = row.timestamp >= since && row.timestamp <= until;
+						if (typeOk && tsOk) results.push(row);
+					}
+					cursor.continue();
+				};
+				req.onerror = () => reject(req.error);
+				t.onerror = () => reject(t.error);
+			});
+
+			return results;
+		},
+
+		async queryScores(walletAddress, appId, filter) {
+			const db = await open();
+			const limit = clampLimit(filter.limit);
+			const since = filter.since ?? Number.NEGATIVE_INFINITY;
+			const until = filter.until ?? Number.POSITIVE_INFINITY;
+			const order = filter.order ?? "value_desc";
+			const indexName =
+				order === "value_desc" ? INDEX_BY_SCOPE_VALUE : INDEX_BY_SCOPE_TS;
+			const lower = [walletAddress, appId, Number.NEGATIVE_INFINITY];
+			const upper = [walletAddress, appId, Number.POSITIVE_INFINITY];
+			const results: StoredScore[] = [];
+
+			await new Promise<void>((resolve, reject) => {
+				const t = db.transaction(STORE, "readonly");
+				const store = t.objectStore(STORE);
+				const idx = store.index(indexName);
+				const range = IDBKeyRange.bound(lower, upper);
+				const req = idx.openCursor(range, "prev");
+				req.onsuccess = () => {
+					const cursor = req.result;
+					if (!cursor || results.length >= limit) {
+						resolve();
+						return;
+					}
+					const row = cursor.value as StoredRecord | StoredScore;
+					if (isStoredScore(row)) {
+						const tsOk = row.timestamp >= since && row.timestamp <= until;
+						if (tsOk) results.push(row);
+					}
+					cursor.continue();
+				};
+				req.onerror = () => reject(req.error);
+				t.onerror = () => reject(t.error);
+			});
+
+			return results;
+		},
+
+		async clearScope(walletAddress, appId) {
+			const db = await open();
+			await new Promise<void>((resolve, reject) => {
+				const t = db.transaction(STORE, "readwrite");
+				const store = t.objectStore(STORE);
+				const idx = store.index(INDEX_BY_SCOPE_TS);
+				const lower = [walletAddress, appId, Number.NEGATIVE_INFINITY];
+				const upper = [walletAddress, appId, Number.POSITIVE_INFINITY];
+				const req = idx.openCursor(IDBKeyRange.bound(lower, upper));
+				req.onsuccess = () => {
+					const cursor = req.result;
+					if (!cursor) {
+						resolve();
+						return;
+					}
+					cursor.delete();
+					cursor.continue();
+				};
+				req.onerror = () => reject(req.error);
+				t.onerror = () => reject(t.error);
+			});
+		},
+
+		async sumBytes(walletAddress, appId) {
+			const db = await open();
+			let total = 0;
+			await new Promise<void>((resolve, reject) => {
+				const t = db.transaction(STORE, "readonly");
+				const store = t.objectStore(STORE);
+				const idx = store.index(INDEX_BY_SCOPE_TS);
+				const lower = [walletAddress, appId, Number.NEGATIVE_INFINITY];
+				const upper = [walletAddress, appId, Number.POSITIVE_INFINITY];
+				const req = idx.openCursor(IDBKeyRange.bound(lower, upper));
+				req.onsuccess = () => {
+					const cursor = req.result;
+					if (!cursor) {
+						resolve();
+						return;
+					}
+					const row = cursor.value as StoredRecord | StoredScore;
+					total += row.sizeBytes;
+					cursor.continue();
+				};
+				req.onerror = () => reject(req.error);
+			});
+			return total;
+		},
+	};
+}
+
+function clampLimit(limit: number | undefined): number {
+	if (limit === undefined || !Number.isFinite(limit) || limit <= 0) return 1000;
+	return Math.min(Math.floor(limit), 1000);
+}

--- a/packages/app-metrics/src/adapters/memory.ts
+++ b/packages/app-metrics/src/adapters/memory.ts
@@ -1,0 +1,72 @@
+import {
+	isStoredScore,
+	type QueryFilter,
+	type ScoreFilter,
+	type StoredRecord,
+	type StoredScore,
+} from "../protocol";
+import type { StorageAdapter } from "./types";
+
+type Row = StoredRecord | StoredScore;
+
+export function createMemoryAdapter(): StorageAdapter {
+	const rows: Row[] = [];
+
+	const scopeFilter = (walletAddress: string, appId: string) => (r: Row) =>
+		r.walletAddress === walletAddress && r.appId === appId;
+
+	return {
+		async put(row) {
+			rows.push(row);
+		},
+		async query(walletAddress, appId, filter) {
+			const limit = clampLimit(filter.limit);
+			const since = filter.since ?? Number.NEGATIVE_INFINITY;
+			const until = filter.until ?? Number.POSITIVE_INFINITY;
+			const result = rows
+				.filter(scopeFilter(walletAddress, appId))
+				.filter((r): r is StoredRecord => !isStoredScore(r))
+				.filter((r) => (filter.type === undefined ? true : r.type === filter.type))
+				.filter((r) => r.timestamp >= since && r.timestamp <= until)
+				.sort((a, b) => b.timestamp - a.timestamp)
+				.slice(0, limit);
+			return result;
+		},
+		async queryScores(walletAddress, appId, filter) {
+			const limit = clampLimit(filter.limit);
+			const since = filter.since ?? Number.NEGATIVE_INFINITY;
+			const until = filter.until ?? Number.POSITIVE_INFINITY;
+			const order = filter.order ?? "value_desc";
+			const result = rows
+				.filter(scopeFilter(walletAddress, appId))
+				.filter(isStoredScore)
+				.filter((r) => r.timestamp >= since && r.timestamp <= until);
+			if (order === "value_desc") {
+				result.sort((a, b) =>
+					b.value === a.value ? b.timestamp - a.timestamp : b.value - a.value,
+				);
+			} else {
+				result.sort((a, b) => b.timestamp - a.timestamp);
+			}
+			return result.slice(0, limit);
+		},
+		async clearScope(walletAddress, appId) {
+			for (let i = rows.length - 1; i >= 0; i--) {
+				const row = rows[i];
+				if (row && row.walletAddress === walletAddress && row.appId === appId) {
+					rows.splice(i, 1);
+				}
+			}
+		},
+		async sumBytes(walletAddress, appId) {
+			return rows
+				.filter(scopeFilter(walletAddress, appId))
+				.reduce((sum, r) => sum + r.sizeBytes, 0);
+		},
+	};
+}
+
+function clampLimit(limit: number | undefined): number {
+	if (limit === undefined || !Number.isFinite(limit) || limit <= 0) return 1000;
+	return Math.min(Math.floor(limit), 1000);
+}

--- a/packages/app-metrics/src/adapters/types.ts
+++ b/packages/app-metrics/src/adapters/types.ts
@@ -1,0 +1,22 @@
+import type {
+	QueryFilter,
+	ScoreFilter,
+	StoredRecord,
+	StoredScore,
+} from "../protocol";
+
+export interface StorageAdapter {
+	put(row: StoredRecord | StoredScore): Promise<void>;
+	query(
+		walletAddress: string,
+		appId: string,
+		filter: QueryFilter,
+	): Promise<StoredRecord[]>;
+	queryScores(
+		walletAddress: string,
+		appId: string,
+		filter: ScoreFilter,
+	): Promise<StoredScore[]>;
+	clearScope(walletAddress: string, appId: string): Promise<void>;
+	sumBytes(walletAddress: string, appId: string): Promise<number>;
+}

--- a/packages/app-metrics/src/client.ts
+++ b/packages/app-metrics/src/client.ts
@@ -1,0 +1,245 @@
+/**
+ * Client that runs inside the sandboxed app iframe.
+ *
+ * Listens for the host's `__elata_metrics_init` message, captures the transferred
+ * `MessagePort`, and exposes a Promise-based API. All calls are async and route
+ * over the port — apps never see raw storage.
+ */
+
+import {
+	type AppRecord,
+	type AppScore,
+	type HostErrorCode,
+	type HostResponse,
+	INIT_MESSAGE_KIND,
+	PROTOCOL_VERSION,
+	type QueryFilter,
+	type ScoreFilter,
+} from "./protocol";
+
+export type {
+	AppRecord,
+	AppScore,
+	HostErrorCode,
+	QueryFilter,
+	ScoreFilter,
+	ScoreOrder,
+} from "./protocol";
+
+export interface MetricsClientOptions {
+	/**
+	 * Window to listen on for the init handshake. Defaults to `window`. Tests
+	 * inject a fake window.
+	 */
+	window?: Window;
+	/**
+	 * Milliseconds to wait for the host handshake before rejecting calls.
+	 * Defaults to 5 seconds. Pass `Infinity` to wait forever.
+	 */
+	handshakeTimeoutMs?: number;
+}
+
+export interface RecordInput {
+	type: string;
+	data: unknown;
+}
+
+export interface SaveScoreInput {
+	value: number;
+	meta?: unknown;
+}
+
+export interface WriteResult {
+	id: string;
+	timestamp: number;
+}
+
+export interface MetricsClient {
+	record(input: RecordInput): Promise<WriteResult>;
+	query(filter?: QueryFilter): Promise<AppRecord[]>;
+	clear(): Promise<void>;
+	saveScore(input: SaveScoreInput): Promise<WriteResult>;
+	loadScores(filter?: ScoreFilter): Promise<AppScore[]>;
+	/** Whether the host handshake has completed. */
+	isReady(): boolean;
+	/** Resolves when the host handshake completes; rejects on timeout. */
+	ready(): Promise<void>;
+	/** Tear down listeners. Pending calls reject with `disposed`. */
+	dispose(): void;
+}
+
+export class MetricsClientError extends Error {
+	readonly code: HostErrorCode | "handshake_timeout" | "disposed" | "transport";
+	constructor(
+		code:
+			| HostErrorCode
+			| "handshake_timeout"
+			| "disposed"
+			| "transport",
+		message: string,
+	) {
+		super(message);
+		this.name = "MetricsClientError";
+		this.code = code;
+	}
+}
+
+interface PendingCall {
+	resolve(value: unknown): void;
+	reject(error: Error): void;
+}
+
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5_000;
+
+export function createMetricsClient(
+	options: MetricsClientOptions = {},
+): MetricsClient {
+	const targetWindow = options.window ?? globalThis.window;
+	if (!targetWindow) {
+		throw new Error(
+			"createMetricsClient: no window available (call this in a browser/jsdom context)",
+		);
+	}
+	const handshakeTimeoutMs =
+		options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
+
+	let port: MessagePort | null = null;
+	let disposed = false;
+	let nextId = 1;
+	const pending = new Map<string, PendingCall>();
+
+	let resolveReady: () => void;
+	let rejectReady: (e: Error) => void;
+	const readyPromise = new Promise<void>((resolve, reject) => {
+		resolveReady = resolve;
+		rejectReady = reject;
+	});
+
+	const handshakeTimer =
+		handshakeTimeoutMs === Number.POSITIVE_INFINITY
+			? null
+			: setTimeout(() => {
+					if (port || disposed) return;
+					const err = new MetricsClientError(
+						"handshake_timeout",
+						`metrics host did not respond within ${handshakeTimeoutMs}ms`,
+					);
+					rejectReady(err);
+					for (const call of pending.values()) call.reject(err);
+					pending.clear();
+				}, handshakeTimeoutMs);
+
+	const onInit = (ev: MessageEvent<unknown>) => {
+		if (port || disposed) return;
+		const data = ev.data as Record<string, unknown> | null;
+		if (!data || data.kind !== INIT_MESSAGE_KIND) return;
+		if (data.v !== PROTOCOL_VERSION) return;
+		const transferred = ev.ports?.[0];
+		if (!transferred) return;
+		port = transferred;
+		port.onmessage = onPortMessage;
+		port.start();
+		if (handshakeTimer) clearTimeout(handshakeTimer);
+		resolveReady();
+	};
+
+	const onPortMessage = (ev: MessageEvent<unknown>) => {
+		const response = ev.data as HostResponse | null;
+		if (
+			!response ||
+			typeof response !== "object" ||
+			typeof (response as { id: unknown }).id !== "string"
+		) {
+			return;
+		}
+		const call = pending.get(response.id);
+		if (!call) return;
+		pending.delete(response.id);
+		if (response.ok) {
+			call.resolve(response.result);
+		} else {
+			call.reject(
+				new MetricsClientError(response.error, `metrics host: ${response.error}`),
+			);
+		}
+	};
+
+	targetWindow.addEventListener("message", onInit);
+
+	const send = <T>(request: Record<string, unknown>): Promise<T> => {
+		if (disposed) {
+			return Promise.reject(
+				new MetricsClientError("disposed", "metrics client disposed"),
+			);
+		}
+		const id = `c_${nextId++}`;
+		const full = { v: PROTOCOL_VERSION, id, ...request };
+		return new Promise<T>((resolve, reject) => {
+			pending.set(id, {
+				resolve: (v) => resolve(v as T),
+				reject,
+			});
+			const dispatch = () => {
+				if (!port) {
+					reject(
+						new MetricsClientError(
+							"transport",
+							"metrics host port not available",
+						),
+					);
+					pending.delete(id);
+					return;
+				}
+				try {
+					port.postMessage(full);
+				} catch (e) {
+					pending.delete(id);
+					reject(
+						new MetricsClientError(
+							"transport",
+							e instanceof Error ? e.message : "postMessage failed",
+						),
+					);
+				}
+			};
+			if (port) {
+				dispatch();
+			} else {
+				readyPromise.then(dispatch, (err) => {
+					pending.delete(id);
+					reject(err);
+				});
+			}
+		});
+	};
+
+	return {
+		isReady: () => port !== null,
+		ready: () => readyPromise,
+		record: (input) =>
+			send<WriteResult>({ op: "record", type: input.type, data: input.data }),
+		query: (filter = {}) => send<AppRecord[]>({ op: "query", filter }),
+		clear: () => send<void>({ op: "clear", scope: "app" }),
+		saveScore: (input) =>
+			send<WriteResult>({
+				op: "saveScore",
+				value: input.value,
+				meta: input.meta,
+			}),
+		loadScores: (filter = {}) => send<AppScore[]>({ op: "loadScores", filter }),
+		dispose() {
+			if (disposed) return;
+			disposed = true;
+			if (handshakeTimer) clearTimeout(handshakeTimer);
+			targetWindow.removeEventListener("message", onInit);
+			if (port) {
+				port.onmessage = null;
+				port.close();
+				port = null;
+			}
+			const err = new MetricsClientError("disposed", "metrics client disposed");
+			for (const call of pending.values()) call.reject(err);
+			pending.clear();
+		},
+	};
+}

--- a/packages/app-metrics/src/host.ts
+++ b/packages/app-metrics/src/host.ts
@@ -1,0 +1,292 @@
+/**
+ * Host entry point. The appstore shell imports `createMetricsHost` from
+ * `@elata-biosciences/app-metrics/host`.
+ *
+ * The host owns IndexedDB and is the only code that touches storage. Apps
+ * inside sandboxed iframes talk to it over a transferred `MessagePort`.
+ */
+
+import { createMemoryAdapter } from "./adapters/memory";
+import type { StorageAdapter } from "./adapters/types";
+import {
+	type ClientRequest,
+	type HostErrorCode,
+	type HostResponse,
+	INIT_MESSAGE_KIND,
+	isClientRequest,
+	isValidScoreValue,
+	isValidType,
+	PROTOCOL_VERSION,
+	type StoredRecord,
+	type StoredScore,
+	toAppRecord,
+	toAppScore,
+} from "./protocol";
+
+export { createIndexedDbAdapter } from "./adapters/indexeddb";
+export { createMemoryAdapter } from "./adapters/memory";
+export type { StorageAdapter } from "./adapters/types";
+export type {
+	AppRecord,
+	AppScore,
+	ClientRequest,
+	HostErrorCode,
+	HostResponse,
+	QueryFilter,
+	ScoreFilter,
+	ScoreOrder,
+	StoredRecord,
+	StoredScore,
+} from "./protocol";
+
+export interface MetricsHostOptions {
+	iframe: HTMLIFrameElement;
+	appId: string;
+	walletAddress: string;
+	storage?: StorageAdapter;
+	quotaBytes?: number;
+	maxRecordBytes?: number;
+	writeRateLimit?: { count: number; windowMs: number };
+	now?: () => number;
+	randomId?: () => string;
+}
+
+export interface MetricsHost {
+	start(): void;
+	stop(): void;
+}
+
+const DEFAULT_QUOTA = 5 * 1024 * 1024;
+const DEFAULT_MAX_RECORD = 64 * 1024;
+const DEFAULT_RATE = { count: 100, windowMs: 60_000 };
+
+export function createMetricsHost(options: MetricsHostOptions): MetricsHost {
+	const {
+		iframe,
+		appId,
+		walletAddress,
+		storage = createMemoryAdapter(),
+		quotaBytes = DEFAULT_QUOTA,
+		maxRecordBytes = DEFAULT_MAX_RECORD,
+		writeRateLimit = DEFAULT_RATE,
+		now = Date.now,
+		randomId = defaultRandomId,
+	} = options;
+
+	if (!appId || typeof appId !== "string") {
+		throw new Error("createMetricsHost: appId is required");
+	}
+	if (!walletAddress || typeof walletAddress !== "string") {
+		throw new Error("createMetricsHost: walletAddress is required");
+	}
+
+	let port: MessagePort | null = null;
+	let stopped = false;
+	const writeTimestamps: number[] = [];
+
+	const respond = (response: HostResponse) => {
+		if (!port || stopped) return;
+		port.postMessage(response);
+	};
+
+	const handleMessage = async (event: MessageEvent<unknown>) => {
+		if (stopped) return;
+		const req = event.data;
+		if (!isClientRequest(req)) {
+			respond({
+				v: 1,
+				id: extractId(req),
+				ok: false,
+				error: "invalid_payload",
+			});
+			return;
+		}
+		try {
+			const response = await dispatch(req);
+			respond(response);
+		} catch {
+			respond({ v: 1, id: req.id, ok: false, error: "internal" });
+		}
+	};
+
+	const dispatch = async (req: ClientRequest): Promise<HostResponse> => {
+		if (req.op === "record") return handleRecord(req);
+		if (req.op === "query") {
+			const rows = await storage.query(walletAddress, appId, req.filter);
+			return { v: 1, id: req.id, ok: true, result: rows.map(toAppRecord) };
+		}
+		if (req.op === "clear") {
+			await storage.clearScope(walletAddress, appId);
+			return { v: 1, id: req.id, ok: true };
+		}
+		if (req.op === "saveScore") return handleSaveScore(req);
+		if (req.op === "loadScores") {
+			const rows = await storage.queryScores(walletAddress, appId, req.filter);
+			return { v: 1, id: req.id, ok: true, result: rows.map(toAppScore) };
+		}
+		return {
+			v: 1,
+			id: (req as { id: string }).id,
+			ok: false,
+			error: "invalid_payload",
+		};
+	};
+
+	const handleRecord = async (
+		req: Extract<ClientRequest, { op: "record" }>,
+	): Promise<HostResponse> => {
+		if (!isValidType(req.type)) {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+		let serialized: string;
+		try {
+			serialized = JSON.stringify(req.data);
+		} catch {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+		if (serialized === undefined) {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+		const sizeBytes = byteLength(serialized);
+		if (sizeBytes > maxRecordBytes) {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+
+		const rateError = checkRate();
+		if (rateError) return { v: 1, id: req.id, ok: false, error: rateError };
+
+		const existing = await storage.sumBytes(walletAddress, appId);
+		if (existing + sizeBytes > quotaBytes) {
+			return { v: 1, id: req.id, ok: false, error: "quota_exceeded" };
+		}
+
+		const record: StoredRecord = {
+			id: randomId(),
+			walletAddress,
+			appId,
+			type: req.type,
+			data: JSON.parse(serialized),
+			timestamp: now(),
+			sizeBytes,
+		};
+		await storage.put(record);
+		return {
+			v: 1,
+			id: req.id,
+			ok: true,
+			result: { id: record.id, timestamp: record.timestamp },
+		};
+	};
+
+	const handleSaveScore = async (
+		req: Extract<ClientRequest, { op: "saveScore" }>,
+	): Promise<HostResponse> => {
+		if (!isValidScoreValue(req.value)) {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+		let serialized: string;
+		try {
+			serialized = JSON.stringify({ value: req.value, meta: req.meta });
+		} catch {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+		if (serialized === undefined) {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+		const sizeBytes = byteLength(serialized);
+		if (sizeBytes > maxRecordBytes) {
+			return { v: 1, id: req.id, ok: false, error: "invalid_payload" };
+		}
+
+		const rateError = checkRate();
+		if (rateError) return { v: 1, id: req.id, ok: false, error: rateError };
+
+		const existing = await storage.sumBytes(walletAddress, appId);
+		if (existing + sizeBytes > quotaBytes) {
+			return { v: 1, id: req.id, ok: false, error: "quota_exceeded" };
+		}
+
+		const score: StoredScore = {
+			id: randomId(),
+			walletAddress,
+			appId,
+			value: req.value,
+			meta: req.meta === undefined ? undefined : JSON.parse(JSON.stringify(req.meta)),
+			timestamp: now(),
+			sizeBytes,
+		};
+		await storage.put(score);
+		return {
+			v: 1,
+			id: req.id,
+			ok: true,
+			result: { id: score.id, timestamp: score.timestamp },
+		};
+	};
+
+	const checkRate = (): HostErrorCode | null => {
+		const t = now();
+		const cutoff = t - writeRateLimit.windowMs;
+		while (writeTimestamps.length > 0 && writeTimestamps[0]! < cutoff) {
+			writeTimestamps.shift();
+		}
+		if (writeTimestamps.length >= writeRateLimit.count) {
+			return "rate_limited";
+		}
+		writeTimestamps.push(t);
+		return null;
+	};
+
+	return {
+		start() {
+			if (stopped) return;
+			const win = iframe.contentWindow;
+			if (!win) {
+				throw new Error(
+					"createMetricsHost: iframe has no contentWindow yet — call start() after onload",
+				);
+			}
+			const channel = new MessageChannel();
+			port = channel.port1;
+			port.onmessage = handleMessage;
+			port.start();
+			win.postMessage(
+				{ kind: INIT_MESSAGE_KIND, v: PROTOCOL_VERSION },
+				"*",
+				[channel.port2],
+			);
+		},
+		stop() {
+			stopped = true;
+			if (port) {
+				port.onmessage = null;
+				port.close();
+				port = null;
+			}
+		},
+	};
+}
+
+function defaultRandomId(): string {
+	const c =
+		typeof globalThis.crypto !== "undefined" && "randomUUID" in globalThis.crypto
+			? globalThis.crypto
+			: undefined;
+	if (c) return c.randomUUID();
+	return `id_${Math.random().toString(36).slice(2)}_${Date.now().toString(36)}`;
+}
+
+function byteLength(s: string): number {
+	if (typeof TextEncoder !== "undefined") {
+		return new TextEncoder().encode(s).byteLength;
+	}
+	return s.length;
+}
+
+function extractId(value: unknown): string {
+	if (value && typeof value === "object" && "id" in value) {
+		const id = (value as { id: unknown }).id;
+		if (typeof id === "string") return id;
+	}
+	return "unknown";
+}

--- a/packages/app-metrics/src/index.ts
+++ b/packages/app-metrics/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Default entry point — for sandboxed apps. Re-exports the client API.
+ *
+ * The appstore host should import from `@elata-biosciences/app-metrics/host`
+ * instead, which keeps host-only code (IndexedDB adapter, dispatch) out of the
+ * app bundle.
+ */
+
+export { createMetricsClient, MetricsClientError } from "./client";
+export type {
+	MetricsClient,
+	MetricsClientOptions,
+	RecordInput,
+	SaveScoreInput,
+	WriteResult,
+} from "./client";
+export type {
+	AppRecord,
+	AppScore,
+	HostErrorCode,
+	QueryFilter,
+	ScoreFilter,
+	ScoreOrder,
+} from "./protocol";

--- a/packages/app-metrics/src/protocol.ts
+++ b/packages/app-metrics/src/protocol.ts
@@ -1,0 +1,147 @@
+/**
+ * Wire protocol between the sandboxed app (client) and the appstore host.
+ *
+ * Transport: MessageChannel. Host posts an init message with `port2` transferred;
+ * the app captures `port1` and uses it for all subsequent traffic.
+ *
+ * Ops: `record` / `query` / `clear` operate on generic per-app metrics records.
+ * `saveScore` / `loadScores` are a specialized append-only score log with
+ * value-sorted reads (top-N) — see docs/STORAGE_SCORES_PLAN.md in the appstore repo.
+ */
+
+export const PROTOCOL_VERSION = 1 as const;
+export const INIT_MESSAGE_KIND = "__elata_metrics_init" as const;
+
+export interface InitMessage {
+	kind: typeof INIT_MESSAGE_KIND;
+	v: typeof PROTOCOL_VERSION;
+}
+
+export interface QueryFilter {
+	type?: string;
+	since?: number;
+	until?: number;
+	limit?: number;
+}
+
+export type ScoreOrder = "value_desc" | "timestamp_desc";
+
+export interface ScoreFilter {
+	order?: ScoreOrder;
+	since?: number;
+	until?: number;
+	limit?: number;
+}
+
+export type ClientRequest =
+	| { v: 1; id: string; op: "record"; type: string; data: unknown }
+	| { v: 1; id: string; op: "query"; filter: QueryFilter }
+	| { v: 1; id: string; op: "clear"; scope: "app" }
+	| { v: 1; id: string; op: "saveScore"; value: number; meta?: unknown }
+	| { v: 1; id: string; op: "loadScores"; filter: ScoreFilter };
+
+export type HostErrorCode =
+	| "quota_exceeded"
+	| "invalid_payload"
+	| "rate_limited"
+	| "internal";
+
+export type HostResponse =
+	| { v: 1; id: string; ok: true; result?: unknown }
+	| { v: 1; id: string; ok: false; error: HostErrorCode };
+
+export interface StoredRecord {
+	id: string;
+	walletAddress: string;
+	appId: string;
+	type: string;
+	data: unknown;
+	timestamp: number;
+	sizeBytes: number;
+}
+
+export interface StoredScore {
+	id: string;
+	walletAddress: string;
+	appId: string;
+	value: number;
+	meta?: unknown;
+	timestamp: number;
+	sizeBytes: number;
+}
+
+export interface AppRecord {
+	id: string;
+	type: string;
+	data: unknown;
+	timestamp: number;
+}
+
+export interface AppScore {
+	id: string;
+	value: number;
+	meta?: unknown;
+	timestamp: number;
+}
+
+const TYPE_PATTERN = /^[a-z][a-z0-9_]{0,63}$/;
+
+export function isValidType(type: unknown): type is string {
+	return typeof type === "string" && TYPE_PATTERN.test(type);
+}
+
+export function isValidScoreValue(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+export function isClientRequest(value: unknown): value is ClientRequest {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.v !== PROTOCOL_VERSION) return false;
+	if (typeof v.id !== "string" || v.id.length === 0) return false;
+	if (v.op === "record") {
+		return isValidType(v.type) && v.data !== undefined;
+	}
+	if (v.op === "query") {
+		return typeof v.filter === "object" && v.filter !== null;
+	}
+	if (v.op === "clear") {
+		return v.scope === "app";
+	}
+	if (v.op === "saveScore") {
+		return isValidScoreValue(v.value);
+	}
+	if (v.op === "loadScores") {
+		return typeof v.filter === "object" && v.filter !== null;
+	}
+	return false;
+}
+
+export function toAppRecord(record: StoredRecord): AppRecord {
+	return {
+		id: record.id,
+		type: record.type,
+		data: record.data,
+		timestamp: record.timestamp,
+	};
+}
+
+export function toAppScore(score: StoredScore): AppScore {
+	return {
+		id: score.id,
+		value: score.value,
+		meta: score.meta,
+		timestamp: score.timestamp,
+	};
+}
+
+/**
+ * Sparse-index marker. A score row in the object store has a `value` field;
+ * a record row does not. This lets the same store hold both, and IndexedDB's
+ * sparse-index semantics keep the value-sorted index scoped to scores only.
+ */
+export function isStoredScore(
+	row: StoredRecord | StoredScore,
+): row is StoredScore {
+	return typeof (row as StoredScore).value === "number";
+}

--- a/packages/app-metrics/tsconfig.json
+++ b/packages/app-metrics/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ES2020",
+		"lib": ["ES2020", "DOM"],
+		"moduleResolution": "Bundler",
+		"rootDir": "src",
+		"outDir": "dist",
+		"declaration": true,
+		"declarationMap": true,
+		"composite": true,
+		"strict": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/__tests__/**", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,27 @@ importers:
         specifier: ^1.51.1
         version: 1.58.2
 
+  packages/app-metrics:
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      fake-indexeddb:
+        specifier: 6.0.0
+        version: 6.0.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@25.3.3)
+      jest-environment-jsdom:
+        specifier: 29.7.0
+        version: 29.7.0
+      ts-jest:
+        specifier: 29.4.4
+        version: 29.4.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.2.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.10)(jest-util@30.2.0)(jest@29.7.0(@types/node@25.3.3))(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/create-elata-demo: {}
 
   packages/eeg-web:
@@ -1096,6 +1117,10 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fake-indexeddb@6.0.0:
+    resolution: {integrity: sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==}
+    engines: {node: '>=18'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -3188,6 +3213,8 @@ snapshots:
       jest-util: 29.7.0
 
   extendable-error@0.1.7: {}
+
+  fake-indexeddb@6.0.0: {}
 
   fast-glob@3.3.3:
     dependencies:


### PR DESCRIPTION
## Summary

- New `@elata-biosciences/app-metrics` package: per-user, per-app storage that sandboxed apps reach through a transferred `MessagePort`. Host owns IndexedDB; apps never touch storage directly.
- Five wire ops: `record` / `query` / `clear` (generic per-app event log) and `saveScore` / `loadScores` (append-only score log with value-sorted top-N reads).
- 37 tests across 4 suites, all green. Coverage 86% stmt / 91% line.

## Package surface

```ts
import { createMetricsClient } from '@elata-biosciences/app-metrics';

const metrics = createMetricsClient();
await metrics.ready();

await metrics.saveScore({ value, meta? });           // host assigns id + timestamp
await metrics.loadScores({ order?, since?, until?, limit? });

await metrics.record({ type, data });                // generic event log
await metrics.query({ type?, since?, until?, limit? });
await metrics.clear();
```

Host entry point at `@elata-biosciences/app-metrics/host` (`createMetricsHost`, `createIndexedDbAdapter`, `createMemoryAdapter`).

## Design notes

- **MessageChannel transport**: host posts a `__elata_metrics_init` message with `port2` transferred; client captures `port1`. All later traffic goes over the port.
- **Pre-handshake call queueing**: client calls made before the handshake completes are queued and dispatched once the port arrives. `handshakeTimeoutMs` (default 5s) rejects queued calls if the host never connects.
- **Shared object store, sparse value index**: scores and records live in the same store. The `by_scope_value` index is sparse (records lack a numeric `value` and are skipped), so top-N-by-value is a cursor walk rather than a full scan.
- **Shared quota / rate limit**: scores share the existing 5 MB per-(wallet, app) quota, 64 KB per-record cap, and 100 writes/min limit. `clearScope` wipes everything.
- **Schema bump 1 → 2**: additive — existing records untouched.

## Test plan

- [x] `pnpm test` — 4 suites, 37 tests, all pass.
- [x] `protocol.test.ts` — validators, request discriminator, sparse-row marker.
- [x] `host.test.ts` — end-to-end via real MessageChannel + memory adapter (saveScore validation, shared quota, ordering, limits).
- [x] `client.test.ts` — handshake captures port, pre-handshake calls queue, dispose rejects pending.
- [x] `indexeddb.test.ts` — sparse index excludes records from queryScores and vice versa; clearScope hits both kinds.
- [ ] Manual: load an app that calls `metrics.saveScore` from a sandboxed iframe in the appstore (paired with appstore PR #456).

## Coordination

Appstore companion: [Elata-Biosciences/elata-appstore#456](https://github.com/Elata-Biosciences/elata-appstore/pull/456) — adds the matching `saveScore`/`loadScores` host dispatch on the appstore side. That repo vendors a copy of `host` + `protocol` for Vercel build reasons (see commit `77de70be` in elata-appstore), so wire-format changes must land in both repos in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)