### PR TITLE
feat(app-payments): add hasItem and getOwnedItems entitlement queries

### DIFF
--- a/.changeset/app-payments-initial.md
+++ b/.changeset/app-payments-initial.md
@@ -1,0 +1,14 @@
+---
+"@elata-biosciences/app-payments": minor
+---
+
+Add `@elata-biosciences/app-payments`: in-app purchases for sandboxed apps in
+the Elata App Store. Apps call `requestPurchase({ contentId, priceUsdc, ... })`
+and `await` the verdict; the package posts an `elata:iap:request` message to
+the parent frame, which owns the payment UI (Thirdweb `CheckoutWidget`, wallet
+or card funding, on-chain USDC settlement) and replies with success / cancelled
+/ error. The price the app sends is a display hint — the host refetches the
+authoritative price before charging. Each request is uniquely identified by a
+`crypto.randomUUID()` `requestId`, giving the host idempotency on retries. The
+package exports `requestPurchase`, `AppPaymentsError`, and the `PurchaseResult`
+union. Browser-only.

--- a/packages/app-payments/README.md
+++ b/packages/app-payments/README.md
@@ -1,0 +1,71 @@
+# @elata-biosciences/app-payments
+
+In-app purchases for sandboxed apps running in the [Elata appstore](https://github.com/Elata-Biosciences/elata-appstore).
+
+The appstore renders apps inside a sandboxed iframe with no wallet or backend access. This package lets the app request a purchase from the parent frame, which owns the payment UI (PayEmbed, wallet, on-chain settlement). The app just declares intent and awaits the verdict.
+
+## Install
+
+```sh
+pnpm add @elata-biosciences/app-payments
+```
+
+## Usage
+
+```ts
+import { requestPurchase } from "@elata-biosciences/app-payments";
+
+async function onChickenStand() {
+  const result = await requestPurchase({
+    contentId: 7,           // issued by the host when the listing was created
+    priceUsdc: "0.01",      // display hint — host refetches the authoritative price
+    title: "Chicken",
+    description: "Unlocks the next level.",
+  });
+
+  switch (result.status) {
+    case "success":
+      unlockNextLevel();
+      console.log("paid in tx", result.txHash);
+      break;
+    case "cancelled":
+      // user closed the modal — leave them where they are
+      break;
+    case "error":
+      showError(result.error);
+      break;
+  }
+}
+```
+
+The promise never rejects on a normal `cancelled` / `error` outcome — those are part of the resolved value. It only rejects on:
+
+| Code            | Meaning                                                       |
+|-----------------|---------------------------------------------------------------|
+| `invalid_input` | `contentId` was not a non-negative integer (or similar)       |
+| `no_window`     | not running in a browser environment                          |
+| `no_parent`     | not running inside an iframe                                  |
+| `no_crypto`     | `crypto.randomUUID` is unavailable                            |
+| `timeout`       | no response within `timeoutMs` (default 5 minutes)            |
+
+All errors are instances of `AppPaymentsError` with a `.code` field.
+
+## How it works
+
+1. Generates a `requestId` via `crypto.randomUUID()`.
+2. Posts `{ type: "elata:iap:request", requestId, contentId, ... }` to `window.parent`.
+3. Listens for `{ type: "elata:iap:result", requestId, status, ... }` from the parent.
+4. Resolves the promise; cleans up the listener and timer.
+
+The parent validates the message source against the app's registered origin before opening the payment modal, refetches the authoritative price from its API (the `priceUsdc` you send is display-only), runs the on-chain settlement, and replies back to the iframe.
+
+## Security model
+
+- The app cannot fabricate ownership. Entitlements are written server-side after the on-chain transaction confirms.
+- The app cannot read card details, wallet keys, or session tokens. The parent owns those surfaces.
+- The price the app sends is a hint. The host always refetches.
+- Each `requestId` is unique; the host's purchase API has `(userId, requestId)` uniqueness so a replayed request returns the existing ownership without charging again.
+
+## Versioning
+
+This package is `0.x` and the protocol is `v1`. Breaking protocol changes will bump both the package major version and the protocol version field.

--- a/packages/app-payments/jest.config.cjs
+++ b/packages/app-payments/jest.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+	transform: {
+		"^.+\\.tsx?$": ["ts-jest", { diagnostics: false }],
+	},
+	testEnvironment: "jsdom",
+	setupFiles: ["<rootDir>/jest.setup.cjs"],
+	testMatch: ["**/__tests__/**/*.test.ts"],
+	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	collectCoverage: true,
+	collectCoverageFrom: ["src/**/*.ts"],
+	coverageDirectory: "coverage",
+};

--- a/packages/app-payments/jest.setup.cjs
+++ b/packages/app-payments/jest.setup.cjs
@@ -1,0 +1,13 @@
+// jsdom shims for APIs the client depends on. Production uses native browser
+// implementations.
+//
+// jsdom does provide `globalThis.crypto`, but its older builds lack
+// `randomUUID`. Patch it in either way.
+
+const nodeWebCrypto = require("node:crypto").webcrypto;
+
+if (typeof globalThis.crypto === "undefined") {
+	globalThis.crypto = nodeWebCrypto;
+} else if (typeof globalThis.crypto.randomUUID !== "function") {
+	globalThis.crypto.randomUUID = nodeWebCrypto.randomUUID.bind(nodeWebCrypto);
+}

--- a/packages/app-payments/package.json
+++ b/packages/app-payments/package.json
@@ -1,0 +1,59 @@
+{
+	"name": "@elata-biosciences/app-payments",
+	"version": "0.1.0",
+	"description": "In-app purchases for sandboxed apps in the Elata appstore",
+	"license": "MIT",
+	"author": "Elata",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Elata-Biosciences/elata-bio-sdk.git",
+		"directory": "packages/app-payments"
+	},
+	"homepage": "https://github.com/Elata-Biosciences/elata-bio-sdk#readme",
+	"bugs": "https://github.com/Elata-Biosciences/elata-bio-sdk/issues",
+	"keywords": [
+		"elata",
+		"appstore",
+		"payments",
+		"iap",
+		"sandbox"
+	],
+	"engines": {
+		"node": ">=20"
+	},
+	"type": "module",
+	"sideEffects": false,
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"lint": "pnpm exec biome lint src jest.config.cjs",
+		"test": "jest --config ./jest.config.cjs --passWithNoTests",
+		"test:coverage": "jest --config ./jest.config.cjs --coverage --passWithNoTests",
+		"clean": "node ./scripts/clean.mjs",
+		"build": "tsc -p tsconfig.json && node ./scripts/fix-dist-import-specifiers.mjs && node ./scripts/verify-dist-esm.mjs",
+		"verify:build": "node ../../scripts/verify-package-build.mjs dist/index.js dist/index.d.ts",
+		"verify:publish": "pnpm run verify:build",
+		"prepare:publish": "pnpm run build",
+		"prepack": "pnpm run prepare:publish && pnpm run verify:publish"
+	},
+	"devDependencies": {
+		"@types/jest": "29.5.14",
+		"jest": "29.7.0",
+		"jest-environment-jsdom": "29.7.0",
+		"ts-jest": "29.4.4",
+		"typescript": "5.9.3"
+	}
+}

--- a/packages/app-payments/scripts/clean.mjs
+++ b/packages/app-payments/scripts/clean.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgDir = path.resolve(__dirname, "..");
+
+const dirs = ["dist", "coverage"];
+const files = ["tsconfig.tsbuildinfo"];
+
+for (const dir of dirs) {
+	const full = path.join(pkgDir, dir);
+	if (fs.existsSync(full)) {
+		fs.rmSync(full, { recursive: true, force: true });
+		console.log("Removed:", dir);
+	}
+}
+for (const file of files) {
+	const full = path.join(pkgDir, file);
+	if (fs.existsSync(full)) {
+		fs.rmSync(full, { force: true });
+		console.log("Removed:", file);
+	}
+}

--- a/packages/app-payments/scripts/fix-dist-import-specifiers.mjs
+++ b/packages/app-payments/scripts/fix-dist-import-specifiers.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+const distDir = path.join(packageRoot, "dist");
+
+const FILE_EXTENSIONS = new Set([".js", ".d.ts"]);
+const SPECIFIER_PATTERN =
+	/((?:import|export)\s[^'"]*?from\s*|import\s*\(\s*)["'](\.{1,2}\/[^"']+)["']/g;
+
+function shouldAppendJs(specifier) {
+	const ext = path.extname(specifier);
+	return !ext;
+}
+
+function rewriteSpecifiers(contents) {
+	return contents.replace(SPECIFIER_PATTERN, (match, prefix, specifier) => {
+		if (!shouldAppendJs(specifier)) return match;
+		const rewritten = `${specifier}.js`;
+		return `${prefix}"${rewritten}"`;
+	});
+}
+
+function rewriteFile(filePath) {
+	const original = fs.readFileSync(filePath, "utf8");
+	const rewritten = rewriteSpecifiers(original);
+	if (rewritten !== original) {
+		fs.writeFileSync(filePath, rewritten);
+	}
+}
+
+function walk(dir) {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			walk(full);
+			continue;
+		}
+		const ext = path.extname(entry.name);
+		const isDts = entry.name.endsWith(".d.ts");
+		if (FILE_EXTENSIONS.has(ext) || isDts) {
+			rewriteFile(full);
+		}
+	}
+}
+
+if (!fs.existsSync(distDir)) {
+	console.error("dist directory not found:", distDir);
+	process.exit(1);
+}
+
+walk(distDir);

--- a/packages/app-payments/scripts/verify-dist-esm.mjs
+++ b/packages/app-payments/scripts/verify-dist-esm.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+
+const packageRoot = process.cwd();
+const distIndex = path.join(packageRoot, "dist", "index.js");
+
+assert.ok(
+	fs.existsSync(distIndex),
+	"dist/index.js must exist before ESM verification",
+);
+
+const indexSource = fs.readFileSync(distIndex, "utf8");
+assert.match(
+	indexSource,
+	/\.\/client\.js"/,
+	"dist/index.js should re-export client using explicit .js specifier",
+);
+
+console.log("dist ESM specifiers OK");

--- a/packages/app-payments/src/__tests__/client.test.ts
+++ b/packages/app-payments/src/__tests__/client.test.ts
@@ -1,0 +1,252 @@
+import { AppPaymentsError, requestPurchase } from "../client";
+import { REQUEST_MESSAGE_TYPE, RESULT_MESSAGE_TYPE } from "../protocol";
+
+/**
+ * Build a fake iframe window that has a distinct parent window. The parent
+ * captures posted messages and exposes a `reply` helper that dispatches a
+ * `MessageEvent` back to the child with `source === parent`.
+ */
+function buildIframeWindow() {
+	const childListeners: Array<(ev: MessageEvent) => void> = [];
+	const parentMessages: Array<{ data: unknown; targetOrigin: string }> = [];
+
+	const parentWindow = {
+		postMessage: (data: unknown, targetOrigin: string) => {
+			parentMessages.push({ data, targetOrigin });
+		},
+	} as unknown as Window;
+
+	const childWindow = {
+		parent: parentWindow,
+		addEventListener: (type: string, fn: EventListener) => {
+			if (type === "message")
+				childListeners.push(fn as (ev: MessageEvent) => void);
+		},
+		removeEventListener: (type: string, fn: EventListener) => {
+			if (type !== "message") return;
+			const i = childListeners.indexOf(fn as (ev: MessageEvent) => void);
+			if (i >= 0) childListeners.splice(i, 1);
+		},
+	} as unknown as Window;
+
+	const replyFromParent = (payload: unknown) => {
+		const event = {
+			data: payload,
+			source: parentWindow,
+			origin: "https://appstore.example",
+		} as unknown as MessageEvent;
+		for (const fn of [...childListeners]) fn(event);
+	};
+
+	const replyFromOther = (payload: unknown) => {
+		const event = {
+			data: payload,
+			source: {} as Window,
+			origin: "https://evil.example",
+		} as unknown as MessageEvent;
+		for (const fn of [...childListeners]) fn(event);
+	};
+
+	return {
+		childWindow,
+		parentMessages,
+		replyFromParent,
+		replyFromOther,
+		listenerCount: () => childListeners.length,
+	};
+}
+
+describe("requestPurchase", () => {
+	it("posts a well-formed elata:iap:request to the parent window", async () => {
+		const fx = buildIframeWindow();
+
+		const promise = requestPurchase({
+			contentId: 7,
+			priceUsdc: "0.01",
+			title: "Chicken",
+			description: "Unlocks next level",
+			window: fx.childWindow,
+		});
+
+		expect(fx.parentMessages).toHaveLength(1);
+		const { data, targetOrigin } = fx.parentMessages[0];
+		expect(targetOrigin).toBe("*");
+		const msg = data as Record<string, unknown>;
+		expect(msg.type).toBe(REQUEST_MESSAGE_TYPE);
+		expect(typeof msg.requestId).toBe("string");
+		expect((msg.requestId as string).length).toBeGreaterThanOrEqual(8);
+		expect(msg.contentId).toBe(7);
+		expect(msg.priceUsdc).toBe("0.01");
+		expect(msg.title).toBe("Chicken");
+		expect(msg.description).toBe("Unlocks next level");
+
+		// Resolve the promise so the test doesn't leak.
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId: msg.requestId,
+			status: "success",
+			txHash: "0xabc",
+		});
+		await promise;
+	});
+
+	it("resolves with success + txHash when the parent replies success", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({ contentId: 1, window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId,
+			status: "success",
+			txHash: "0xdeadbeef",
+		});
+
+		const result = await promise;
+		expect(result).toEqual({
+			status: "success",
+			requestId,
+			txHash: "0xdeadbeef",
+		});
+		expect(fx.listenerCount()).toBe(0);
+	});
+
+	it("resolves with cancelled when the parent replies cancelled", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({ contentId: 1, window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId,
+			status: "cancelled",
+		});
+
+		const result = await promise;
+		expect(result).toEqual({ status: "cancelled", requestId });
+	});
+
+	it("resolves with error + message when the parent replies error", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({ contentId: 1, window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId,
+			status: "error",
+			error: "insufficient_funds",
+		});
+
+		const result = await promise;
+		expect(result).toEqual({
+			status: "error",
+			requestId,
+			error: "insufficient_funds",
+		});
+	});
+
+	it("ignores result messages from a non-parent source", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({
+			contentId: 1,
+			window: fx.childWindow,
+			timeoutMs: 50,
+		});
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		// Spoofed message from a different source — must be ignored.
+		fx.replyFromOther({
+			type: RESULT_MESSAGE_TYPE,
+			requestId,
+			status: "success",
+			txHash: "0xspoof",
+		});
+
+		await expect(promise).rejects.toThrow(AppPaymentsError);
+	});
+
+	it("ignores result messages with a mismatched requestId", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({
+			contentId: 1,
+			window: fx.childWindow,
+			timeoutMs: 50,
+		});
+
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId: "some-other-id",
+			status: "success",
+			txHash: "0x",
+		});
+
+		await expect(promise).rejects.toThrow(AppPaymentsError);
+	});
+
+	it("rejects with timeout when no result arrives in time", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({
+			contentId: 1,
+			window: fx.childWindow,
+			timeoutMs: 10,
+		});
+
+		await expect(promise).rejects.toMatchObject({
+			name: "AppPaymentsError",
+			code: "timeout",
+		});
+		expect(fx.listenerCount()).toBe(0);
+	});
+
+	it("rejects synchronously when contentId is not a non-negative integer", () => {
+		const fx = buildIframeWindow();
+		expect(() =>
+			requestPurchase({ contentId: -1, window: fx.childWindow }),
+		).toThrow(AppPaymentsError);
+		expect(() =>
+			requestPurchase({ contentId: 1.5, window: fx.childWindow }),
+		).toThrow(AppPaymentsError);
+		expect(() =>
+			requestPurchase({
+				contentId: "1" as unknown as number,
+				window: fx.childWindow,
+			}),
+		).toThrow(AppPaymentsError);
+	});
+
+	it("rejects when called outside an iframe (parent === self)", () => {
+		const sameWindow = {} as Window;
+		(sameWindow as { parent: Window }).parent = sameWindow;
+		expect(() =>
+			requestPurchase({ contentId: 1, window: sameWindow }),
+		).toThrow(AppPaymentsError);
+	});
+
+	it("does not send a second response after the first one settles", async () => {
+		const fx = buildIframeWindow();
+		const promise = requestPurchase({ contentId: 1, window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId,
+			status: "success",
+			txHash: "0x1",
+		});
+		// A duplicate from a buggy host must not flip the result.
+		fx.replyFromParent({
+			type: RESULT_MESSAGE_TYPE,
+			requestId,
+			status: "cancelled",
+		});
+
+		const result = await promise;
+		expect(result.status).toBe("success");
+	});
+});

--- a/packages/app-payments/src/__tests__/client.test.ts
+++ b/packages/app-payments/src/__tests__/client.test.ts
@@ -1,5 +1,17 @@
-import { AppPaymentsError, requestPurchase } from "../client";
-import { REQUEST_MESSAGE_TYPE, RESULT_MESSAGE_TYPE } from "../protocol";
+import {
+	AppPaymentsError,
+	getOwnedItems,
+	hasItem,
+	requestPurchase,
+} from "../client";
+import {
+	HAS_ITEM_MESSAGE_TYPE,
+	HAS_ITEM_RESULT_MESSAGE_TYPE,
+	LIST_OWNED_MESSAGE_TYPE,
+	LIST_OWNED_RESULT_MESSAGE_TYPE,
+	REQUEST_MESSAGE_TYPE,
+	RESULT_MESSAGE_TYPE,
+} from "../protocol";
 
 /**
  * Build a fake iframe window that has a distinct parent window. The parent
@@ -248,5 +260,188 @@ describe("requestPurchase", () => {
 
 		const result = await promise;
 		expect(result.status).toBe("success");
+	});
+});
+
+describe("hasItem", () => {
+	it("posts a well-formed elata:iap:hasItem message to the parent", async () => {
+		const fx = buildIframeWindow();
+		const promise = hasItem(7, { window: fx.childWindow });
+
+		expect(fx.parentMessages).toHaveLength(1);
+		const { data, targetOrigin } = fx.parentMessages[0];
+		expect(targetOrigin).toBe("*");
+		const msg = data as Record<string, unknown>;
+		expect(msg.type).toBe(HAS_ITEM_MESSAGE_TYPE);
+		expect(typeof msg.requestId).toBe("string");
+		expect(msg.contentId).toBe(7);
+
+		fx.replyFromParent({
+			type: HAS_ITEM_RESULT_MESSAGE_TYPE,
+			requestId: msg.requestId,
+			owned: true,
+		});
+		await promise;
+	});
+
+	it("resolves true when the parent reports the item is owned", async () => {
+		const fx = buildIframeWindow();
+		const promise = hasItem(3, { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: HAS_ITEM_RESULT_MESSAGE_TYPE,
+			requestId,
+			owned: true,
+		});
+
+		await expect(promise).resolves.toBe(true);
+		expect(fx.listenerCount()).toBe(0);
+	});
+
+	it("resolves false when the parent reports the item is not owned", async () => {
+		const fx = buildIframeWindow();
+		const promise = hasItem(3, { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: HAS_ITEM_RESULT_MESSAGE_TYPE,
+			requestId,
+			owned: false,
+		});
+
+		await expect(promise).resolves.toBe(false);
+	});
+
+	it("rejects with not_authenticated when the parent reports that error", async () => {
+		const fx = buildIframeWindow();
+		const promise = hasItem(3, { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: HAS_ITEM_RESULT_MESSAGE_TYPE,
+			requestId,
+			error: "not_authenticated",
+		});
+
+		await expect(promise).rejects.toMatchObject({
+			name: "AppPaymentsError",
+			code: "not_authenticated",
+		});
+	});
+
+	it("rejects with fetch_failed for other host errors", async () => {
+		const fx = buildIframeWindow();
+		const promise = hasItem(3, { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: HAS_ITEM_RESULT_MESSAGE_TYPE,
+			requestId,
+			error: "anything_else",
+		});
+
+		await expect(promise).rejects.toMatchObject({ code: "fetch_failed" });
+	});
+
+	it("ignores results from a non-parent source", async () => {
+		const fx = buildIframeWindow();
+		const promise = hasItem(3, { window: fx.childWindow, timeoutMs: 50 });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromOther({
+			type: HAS_ITEM_RESULT_MESSAGE_TYPE,
+			requestId,
+			owned: true,
+		});
+
+		await expect(promise).rejects.toMatchObject({ code: "timeout" });
+	});
+
+	it("rejects synchronously when contentId is invalid", () => {
+		const fx = buildIframeWindow();
+		expect(() => hasItem(-1, { window: fx.childWindow })).toThrow(
+			AppPaymentsError,
+		);
+		expect(() => hasItem(1.5, { window: fx.childWindow })).toThrow(
+			AppPaymentsError,
+		);
+	});
+});
+
+describe("getOwnedItems", () => {
+	it("posts a well-formed elata:iap:listOwned message to the parent", async () => {
+		const fx = buildIframeWindow();
+		const promise = getOwnedItems({ window: fx.childWindow });
+
+		expect(fx.parentMessages).toHaveLength(1);
+		const msg = fx.parentMessages[0].data as Record<string, unknown>;
+		expect(msg.type).toBe(LIST_OWNED_MESSAGE_TYPE);
+		expect(typeof msg.requestId).toBe("string");
+		expect("contentId" in msg).toBe(false);
+
+		fx.replyFromParent({
+			type: LIST_OWNED_RESULT_MESSAGE_TYPE,
+			requestId: msg.requestId,
+			ownedContentIds: [],
+		});
+		await promise;
+	});
+
+	it("resolves with the parent-supplied array of contentIds", async () => {
+		const fx = buildIframeWindow();
+		const promise = getOwnedItems({ window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: LIST_OWNED_RESULT_MESSAGE_TYPE,
+			requestId,
+			ownedContentIds: [2, 5, 9],
+		});
+
+		await expect(promise).resolves.toEqual([2, 5, 9]);
+	});
+
+	it("filters non-integer entries out of ownedContentIds", async () => {
+		const fx = buildIframeWindow();
+		const promise = getOwnedItems({ window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: LIST_OWNED_RESULT_MESSAGE_TYPE,
+			requestId,
+			ownedContentIds: [1, "two", 3.5, 4],
+		});
+
+		await expect(promise).resolves.toEqual([1, 4]);
+	});
+
+	it("rejects with timeout when no result arrives in time", async () => {
+		const fx = buildIframeWindow();
+		const promise = getOwnedItems({ window: fx.childWindow, timeoutMs: 10 });
+		await expect(promise).rejects.toMatchObject({ code: "timeout" });
+		expect(fx.listenerCount()).toBe(0);
+	});
+
+	it("rejects with fetch_failed on host error", async () => {
+		const fx = buildIframeWindow();
+		const promise = getOwnedItems({ window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+
+		fx.replyFromParent({
+			type: LIST_OWNED_RESULT_MESSAGE_TYPE,
+			requestId,
+			error: "boom",
+		});
+
+		await expect(promise).rejects.toMatchObject({ code: "fetch_failed" });
 	});
 });

--- a/packages/app-payments/src/client.ts
+++ b/packages/app-payments/src/client.ts
@@ -8,12 +8,18 @@
  */
 
 import {
+	HAS_ITEM_MESSAGE_TYPE,
+	type IapHasItemMessage,
+	type IapListOwnedMessage,
 	type IapRequestMessage,
 	type IapStatus,
-	isIapResultMessage,
+	LIST_OWNED_MESSAGE_TYPE,
 	REQUEST_ID_MAX_LENGTH,
 	REQUEST_ID_MIN_LENGTH,
 	REQUEST_MESSAGE_TYPE,
+	isIapHasItemResultMessage,
+	isIapListOwnedResultMessage,
+	isIapResultMessage,
 } from "./protocol";
 
 export type { IapStatus } from "./protocol";
@@ -55,17 +61,18 @@ export type PurchaseResult =
 	| PurchaseCancelled
 	| PurchaseError;
 
+export type AppPaymentsErrorCode =
+	| "no_window"
+	| "no_parent"
+	| "invalid_input"
+	| "timeout"
+	| "no_crypto"
+	| "not_authenticated"
+	| "fetch_failed";
+
 export class AppPaymentsError extends Error {
-	readonly code:
-		| "no_window"
-		| "no_parent"
-		| "invalid_input"
-		| "timeout"
-		| "no_crypto";
-	constructor(
-		code: "no_window" | "no_parent" | "invalid_input" | "timeout" | "no_crypto",
-		message: string,
-	) {
+	readonly code: AppPaymentsErrorCode;
+	constructor(code: AppPaymentsErrorCode, message: string) {
 		super(message);
 		this.name = "AppPaymentsError";
 		this.code = code;
@@ -225,6 +232,244 @@ export function requestPurchase(
 					new AppPaymentsError(
 						"timeout",
 						`no purchase result within ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+		}
+
+		try {
+			parent.postMessage(message, "*");
+		} catch (e) {
+			fail(
+				new AppPaymentsError(
+					"invalid_input",
+					e instanceof Error ? e.message : "postMessage failed",
+				),
+			);
+		}
+	});
+}
+
+export interface EntitlementQueryInput {
+	/** Default 10 seconds. Pass `Infinity` to wait forever. */
+	timeoutMs?: number;
+	/** Optional override for testing. Defaults to the global `window`. */
+	window?: Window;
+}
+
+const DEFAULT_QUERY_TIMEOUT_MS = 10_000;
+
+function resolveParent(targetWindow: Window | undefined): {
+	targetWindow: Window;
+	parent: Window;
+} {
+	const tw = targetWindow ?? globalThis.window;
+	if (!tw) {
+		throw new AppPaymentsError(
+			"no_window",
+			"no window available (call entitlement queries in a browser context)",
+		);
+	}
+	const parent = tw.parent;
+	if (!parent || parent === tw) {
+		throw new AppPaymentsError(
+			"no_parent",
+			"entitlement queries must run inside an iframe with an appstore parent",
+		);
+	}
+	return { targetWindow: tw, parent };
+}
+
+function generateQueryRequestId(): string {
+	const requestId = generateRequestId();
+	if (
+		requestId.length < REQUEST_ID_MIN_LENGTH ||
+		requestId.length > REQUEST_ID_MAX_LENGTH
+	) {
+		throw new AppPaymentsError(
+			"invalid_input",
+			`generated requestId outside host bounds [${REQUEST_ID_MIN_LENGTH}, ${REQUEST_ID_MAX_LENGTH}]`,
+		);
+	}
+	return requestId;
+}
+
+/**
+ * Ask the appstore host whether the session user owns a given offchain item.
+ *
+ * Resolves with `true` / `false` on a clean answer. Throws `AppPaymentsError`
+ * on local failures (`no_parent`, `timeout`, `invalid_input`) or host
+ * failures (`not_authenticated`, `fetch_failed`).
+ *
+ * @example
+ *   if (await hasItem(7)) unlockPermanentSkin();
+ */
+export function hasItem(
+	contentId: number,
+	opts: EntitlementQueryInput = {},
+): Promise<boolean> {
+	if (
+		typeof contentId !== "number" ||
+		!Number.isInteger(contentId) ||
+		contentId < 0
+	) {
+		throw new AppPaymentsError(
+			"invalid_input",
+			"contentId must be a non-negative integer",
+		);
+	}
+	if (opts.timeoutMs !== undefined && typeof opts.timeoutMs !== "number") {
+		throw new AppPaymentsError("invalid_input", "timeoutMs must be a number");
+	}
+
+	const { targetWindow, parent } = resolveParent(opts.window);
+	const requestId = generateQueryRequestId();
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS;
+
+	const message: IapHasItemMessage = {
+		type: HAS_ITEM_MESSAGE_TYPE,
+		requestId,
+		contentId,
+	};
+
+	return new Promise<boolean>((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const cleanup = () => {
+			targetWindow.removeEventListener("message", onMessage);
+			if (timer !== null) clearTimeout(timer);
+		};
+		const settle = (value: boolean) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(value);
+		};
+		const fail = (err: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(err);
+		};
+
+		const onMessage = (ev: MessageEvent<unknown>) => {
+			if (ev.source !== parent) return;
+			if (!isIapHasItemResultMessage(ev.data)) return;
+			if (ev.data.requestId !== requestId) return;
+			if (typeof ev.data.error === "string") {
+				const code: AppPaymentsErrorCode =
+					ev.data.error === "not_authenticated"
+						? "not_authenticated"
+						: "fetch_failed";
+				fail(new AppPaymentsError(code, ev.data.error));
+				return;
+			}
+			settle(ev.data.owned === true);
+		};
+
+		targetWindow.addEventListener("message", onMessage);
+
+		if (timeoutMs !== Number.POSITIVE_INFINITY) {
+			timer = setTimeout(() => {
+				fail(
+					new AppPaymentsError(
+						"timeout",
+						`no hasItem result within ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+		}
+
+		try {
+			parent.postMessage(message, "*");
+		} catch (e) {
+			fail(
+				new AppPaymentsError(
+					"invalid_input",
+					e instanceof Error ? e.message : "postMessage failed",
+				),
+			);
+		}
+	});
+}
+
+/**
+ * List every offchain `contentId` the session user owns for this app.
+ *
+ * Resolves with a sorted ascending array (possibly empty). Same error model
+ * as `hasItem`.
+ *
+ * @example
+ *   const owned = await getOwnedItems();
+ *   owned.forEach(restoreItem);
+ */
+export function getOwnedItems(
+	opts: EntitlementQueryInput = {},
+): Promise<number[]> {
+	if (opts.timeoutMs !== undefined && typeof opts.timeoutMs !== "number") {
+		throw new AppPaymentsError("invalid_input", "timeoutMs must be a number");
+	}
+
+	const { targetWindow, parent } = resolveParent(opts.window);
+	const requestId = generateQueryRequestId();
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_QUERY_TIMEOUT_MS;
+
+	const message: IapListOwnedMessage = {
+		type: LIST_OWNED_MESSAGE_TYPE,
+		requestId,
+	};
+
+	return new Promise<number[]>((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const cleanup = () => {
+			targetWindow.removeEventListener("message", onMessage);
+			if (timer !== null) clearTimeout(timer);
+		};
+		const settle = (value: number[]) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(value);
+		};
+		const fail = (err: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(err);
+		};
+
+		const onMessage = (ev: MessageEvent<unknown>) => {
+			if (ev.source !== parent) return;
+			if (!isIapListOwnedResultMessage(ev.data)) return;
+			if (ev.data.requestId !== requestId) return;
+			if (typeof ev.data.error === "string") {
+				const code: AppPaymentsErrorCode =
+					ev.data.error === "not_authenticated"
+						? "not_authenticated"
+						: "fetch_failed";
+				fail(new AppPaymentsError(code, ev.data.error));
+				return;
+			}
+			const ids = Array.isArray(ev.data.ownedContentIds)
+				? ev.data.ownedContentIds.filter(
+						(id): id is number =>
+							typeof id === "number" && Number.isInteger(id),
+					)
+				: [];
+			settle(ids);
+		};
+
+		targetWindow.addEventListener("message", onMessage);
+
+		if (timeoutMs !== Number.POSITIVE_INFINITY) {
+			timer = setTimeout(() => {
+				fail(
+					new AppPaymentsError(
+						"timeout",
+						`no getOwnedItems result within ${timeoutMs}ms`,
 					),
 				);
 			}, timeoutMs);

--- a/packages/app-payments/src/client.ts
+++ b/packages/app-payments/src/client.ts
@@ -1,0 +1,244 @@
+/**
+ * Client API for sandboxed apps to request an in-app purchase from the
+ * appstore host. Single async function — generates a requestId, posts the
+ * request to `window.parent`, waits for the matching result, and resolves.
+ *
+ * The host owns the payment UI (wallet, PayEmbed, on-chain tx). This client
+ * just declares intent and awaits the outcome.
+ */
+
+import {
+	type IapRequestMessage,
+	type IapStatus,
+	isIapResultMessage,
+	REQUEST_ID_MAX_LENGTH,
+	REQUEST_ID_MIN_LENGTH,
+	REQUEST_MESSAGE_TYPE,
+} from "./protocol";
+
+export type { IapStatus } from "./protocol";
+
+export interface RequestPurchaseInput {
+	/** Integer `contentId` issued by the host when the listing was created. */
+	contentId: number;
+	/** Optional display hint shown while the modal loads. Host is authoritative. */
+	priceUsdc?: string;
+	/** Optional display title. Host overrides from listing metadata when present. */
+	title?: string;
+	/** Optional display description. */
+	description?: string;
+	/** Default 5 minutes. Pass `Infinity` to wait forever. */
+	timeoutMs?: number;
+	/** Optional override for testing. Defaults to the global `window`. */
+	window?: Window;
+}
+
+export interface PurchaseSuccess {
+	status: "success";
+	requestId: string;
+	txHash: string;
+}
+
+export interface PurchaseCancelled {
+	status: "cancelled";
+	requestId: string;
+}
+
+export interface PurchaseError {
+	status: "error";
+	requestId: string;
+	error: string;
+}
+
+export type PurchaseResult =
+	| PurchaseSuccess
+	| PurchaseCancelled
+	| PurchaseError;
+
+export class AppPaymentsError extends Error {
+	readonly code:
+		| "no_window"
+		| "no_parent"
+		| "invalid_input"
+		| "timeout"
+		| "no_crypto";
+	constructor(
+		code: "no_window" | "no_parent" | "invalid_input" | "timeout" | "no_crypto",
+		message: string,
+	) {
+		super(message);
+		this.name = "AppPaymentsError";
+		this.code = code;
+	}
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+
+function generateRequestId(): string {
+	const c = globalThis.crypto;
+	if (!c || typeof c.randomUUID !== "function") {
+		throw new AppPaymentsError(
+			"no_crypto",
+			"crypto.randomUUID not available in this environment",
+		);
+	}
+	return c.randomUUID();
+}
+
+function validateInput(input: RequestPurchaseInput): void {
+	if (
+		typeof input.contentId !== "number" ||
+		!Number.isInteger(input.contentId) ||
+		input.contentId < 0
+	) {
+		throw new AppPaymentsError(
+			"invalid_input",
+			"contentId must be a non-negative integer",
+		);
+	}
+	if (input.priceUsdc !== undefined && typeof input.priceUsdc !== "string") {
+		throw new AppPaymentsError("invalid_input", "priceUsdc must be a string");
+	}
+	if (input.title !== undefined && typeof input.title !== "string") {
+		throw new AppPaymentsError("invalid_input", "title must be a string");
+	}
+	if (
+		input.description !== undefined &&
+		typeof input.description !== "string"
+	) {
+		throw new AppPaymentsError("invalid_input", "description must be a string");
+	}
+}
+
+/**
+ * Request an in-app purchase. Resolves with the host's verdict.
+ *
+ * The promise never rejects on a normal `cancelled` or `error` outcome — those
+ * are returned as `PurchaseResult`. It only rejects on local failures: invalid
+ * input, missing browser APIs, or timeout.
+ *
+ * @example
+ *   const result = await requestPurchase({ contentId: 7, priceUsdc: "0.01", title: "Chicken" });
+ *   if (result.status === "success") unlockNextLevel();
+ */
+export function requestPurchase(
+	input: RequestPurchaseInput,
+): Promise<PurchaseResult> {
+	validateInput(input);
+
+	const targetWindow = input.window ?? globalThis.window;
+	if (!targetWindow) {
+		throw new AppPaymentsError(
+			"no_window",
+			"no window available (call requestPurchase in a browser context)",
+		);
+	}
+	const parent = targetWindow.parent;
+	if (!parent || parent === targetWindow) {
+		throw new AppPaymentsError(
+			"no_parent",
+			"requestPurchase must run inside an iframe with an appstore parent",
+		);
+	}
+
+	const requestId = generateRequestId();
+	// Defensive: crypto.randomUUID is 36 chars — well within host bounds.
+	// Re-checking guards against future ID schemes drifting out of range.
+	if (
+		requestId.length < REQUEST_ID_MIN_LENGTH ||
+		requestId.length > REQUEST_ID_MAX_LENGTH
+	) {
+		throw new AppPaymentsError(
+			"invalid_input",
+			`generated requestId outside host bounds [${REQUEST_ID_MIN_LENGTH}, ${REQUEST_ID_MAX_LENGTH}]`,
+		);
+	}
+
+	const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	const message: IapRequestMessage = {
+		type: REQUEST_MESSAGE_TYPE,
+		requestId,
+		contentId: input.contentId,
+	};
+	if (input.priceUsdc !== undefined) message.priceUsdc = input.priceUsdc;
+	if (input.title !== undefined) message.title = input.title;
+	if (input.description !== undefined) message.description = input.description;
+
+	return new Promise<PurchaseResult>((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const cleanup = () => {
+			targetWindow.removeEventListener("message", onMessage);
+			if (timer !== null) clearTimeout(timer);
+		};
+
+		const settle = (result: PurchaseResult) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(result);
+		};
+
+		const fail = (err: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(err);
+		};
+
+		const onMessage = (ev: MessageEvent<unknown>) => {
+			// Only accept messages from our parent window. The iframe cannot be
+			// addressed by anything other than the parent (and itself), but this
+			// is a cheap belt-and-suspenders check.
+			if (ev.source !== parent) return;
+			if (!isIapResultMessage(ev.data)) return;
+			if (ev.data.requestId !== requestId) return;
+
+			const status: IapStatus = ev.data.status;
+			if (status === "success") {
+				settle({
+					status: "success",
+					requestId,
+					txHash: typeof ev.data.txHash === "string" ? ev.data.txHash : "",
+				});
+				return;
+			}
+			if (status === "cancelled") {
+				settle({ status: "cancelled", requestId });
+				return;
+			}
+			settle({
+				status: "error",
+				requestId,
+				error:
+					typeof ev.data.error === "string" ? ev.data.error : "unknown error",
+			});
+		};
+
+		targetWindow.addEventListener("message", onMessage);
+
+		if (timeoutMs !== Number.POSITIVE_INFINITY) {
+			timer = setTimeout(() => {
+				fail(
+					new AppPaymentsError(
+						"timeout",
+						`no purchase result within ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+		}
+
+		try {
+			parent.postMessage(message, "*");
+		} catch (e) {
+			fail(
+				new AppPaymentsError(
+					"invalid_input",
+					e instanceof Error ? e.message : "postMessage failed",
+				),
+			);
+		}
+	});
+}

--- a/packages/app-payments/src/index.ts
+++ b/packages/app-payments/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Public API for sandboxed apps. The appstore host has its own listener
+ * inside the parent frame; apps do not import anything from this package
+ * to handle responses — they `await requestPurchase(...)`.
+ */
+
+export { AppPaymentsError, requestPurchase } from "./client";
+export type {
+	PurchaseCancelled,
+	PurchaseError,
+	PurchaseResult,
+	PurchaseSuccess,
+	RequestPurchaseInput,
+} from "./client";
+export type { IapStatus } from "./protocol";

--- a/packages/app-payments/src/index.ts
+++ b/packages/app-payments/src/index.ts
@@ -4,8 +4,15 @@
  * to handle responses — they `await requestPurchase(...)`.
  */
 
-export { AppPaymentsError, requestPurchase } from "./client";
+export {
+	AppPaymentsError,
+	getOwnedItems,
+	hasItem,
+	requestPurchase,
+} from "./client";
 export type {
+	AppPaymentsErrorCode,
+	EntitlementQueryInput,
 	PurchaseCancelled,
 	PurchaseError,
 	PurchaseResult,

--- a/packages/app-payments/src/protocol.ts
+++ b/packages/app-payments/src/protocol.ts
@@ -13,6 +13,11 @@
 export const PROTOCOL_VERSION = 1 as const;
 export const REQUEST_MESSAGE_TYPE = "elata:iap:request" as const;
 export const RESULT_MESSAGE_TYPE = "elata:iap:result" as const;
+export const HAS_ITEM_MESSAGE_TYPE = "elata:iap:hasItem" as const;
+export const HAS_ITEM_RESULT_MESSAGE_TYPE = "elata:iap:hasItem:result" as const;
+export const LIST_OWNED_MESSAGE_TYPE = "elata:iap:listOwned" as const;
+export const LIST_OWNED_RESULT_MESSAGE_TYPE =
+	"elata:iap:listOwned:result" as const;
 
 /** Host-enforced bounds on `requestId` length. Mirror these on the client. */
 export const REQUEST_ID_MIN_LENGTH = 8;
@@ -50,5 +55,60 @@ export function isIapResultMessage(value: unknown): value is IapResultMessage {
 	) {
 		return false;
 	}
+	return true;
+}
+
+/**
+ * Entitlement query: does the session user own a given offchain item?
+ * Reply is `IapHasItemResultMessage`.
+ */
+export interface IapHasItemMessage {
+	type: typeof HAS_ITEM_MESSAGE_TYPE;
+	requestId: string;
+	contentId: number;
+}
+
+export interface IapHasItemResultMessage {
+	type: typeof HAS_ITEM_RESULT_MESSAGE_TYPE;
+	requestId: string;
+	/** Present when the query succeeded. */
+	owned?: boolean;
+	/** Present when the query failed (e.g. `not_authenticated`, `fetch_failed`). */
+	error?: string;
+}
+
+export function isIapHasItemResultMessage(
+	value: unknown,
+): value is IapHasItemResultMessage {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.type !== HAS_ITEM_RESULT_MESSAGE_TYPE) return false;
+	if (typeof v.requestId !== "string") return false;
+	return true;
+}
+
+/**
+ * Entitlement query: list every offchain `contentId` the session user owns
+ * for this app. Reply is `IapListOwnedResultMessage`.
+ */
+export interface IapListOwnedMessage {
+	type: typeof LIST_OWNED_MESSAGE_TYPE;
+	requestId: string;
+}
+
+export interface IapListOwnedResultMessage {
+	type: typeof LIST_OWNED_RESULT_MESSAGE_TYPE;
+	requestId: string;
+	ownedContentIds?: number[];
+	error?: string;
+}
+
+export function isIapListOwnedResultMessage(
+	value: unknown,
+): value is IapListOwnedResultMessage {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.type !== LIST_OWNED_RESULT_MESSAGE_TYPE) return false;
+	if (typeof v.requestId !== "string") return false;
 	return true;
 }

--- a/packages/app-payments/src/protocol.ts
+++ b/packages/app-payments/src/protocol.ts
@@ -1,0 +1,54 @@
+/**
+ * Wire protocol between the sandboxed app (client) and the appstore host.
+ *
+ * One-shot request/response over `window.parent.postMessage`. The app sends an
+ * `elata:iap:request`; the parent renders a payment modal outside the iframe
+ * and replies with an `elata:iap:result` matching on `requestId`.
+ *
+ * The host (PlayHeader) validates `event.origin === embedOrigin` before
+ * accepting a request. The app sends with target origin `"*"` because it does
+ * not know its parent's origin; the host-side origin check is what matters.
+ */
+
+export const PROTOCOL_VERSION = 1 as const;
+export const REQUEST_MESSAGE_TYPE = "elata:iap:request" as const;
+export const RESULT_MESSAGE_TYPE = "elata:iap:result" as const;
+
+/** Host-enforced bounds on `requestId` length. Mirror these on the client. */
+export const REQUEST_ID_MIN_LENGTH = 8;
+export const REQUEST_ID_MAX_LENGTH = 128;
+
+export interface IapRequestMessage {
+	type: typeof REQUEST_MESSAGE_TYPE;
+	requestId: string;
+	contentId: number;
+	/** Display hint only — the host refetches the authoritative price. */
+	priceUsdc?: string;
+	title?: string;
+	description?: string;
+}
+
+export type IapStatus = "success" | "cancelled" | "error";
+
+export interface IapResultMessage {
+	type: typeof RESULT_MESSAGE_TYPE;
+	requestId: string;
+	status: IapStatus;
+	txHash?: string;
+	error?: string;
+}
+
+export function isIapResultMessage(value: unknown): value is IapResultMessage {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.type !== RESULT_MESSAGE_TYPE) return false;
+	if (typeof v.requestId !== "string") return false;
+	if (
+		v.status !== "success" &&
+		v.status !== "cancelled" &&
+		v.status !== "error"
+	) {
+		return false;
+	}
+	return true;
+}

--- a/packages/app-payments/tsconfig.json
+++ b/packages/app-payments/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ES2020",
+		"lib": ["ES2020", "DOM"],
+		"moduleResolution": "Bundler",
+		"rootDir": "src",
+		"outDir": "dist",
+		"declaration": true,
+		"declarationMap": true,
+		"composite": true,
+		"strict": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/__tests__/**", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,24 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/app-payments:
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@25.3.3)
+      jest-environment-jsdom:
+        specifier: 29.7.0
+        version: 29.7.0
+      ts-jest:
+        specifier: 29.4.4
+        version: 29.4.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.2.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.10)(jest-util@30.2.0)(jest@29.7.0(@types/node@25.3.3))(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/create-elata-demo: {}
 
   packages/eeg-web:


### PR DESCRIPTION
## Summary
Two new SDK methods that let sandboxed apps query the session user's offchain entitlements:

```ts
if (await hasItem(7)) unlockPermanentSkin();
const owned = await getOwnedItems();
```

Same `postMessage` round-trip / promise / timeout pattern as `requestPurchase`, but resolve directly to `boolean` / `number[]` rather than a discriminated union — query failures are exceptional, not part of the normal flow.

## Why
Pairs with appstore PR Elata-Biosciences/elata-appstore#TBD, which adds the matching host handler in `PlayHeader.tsx` and a session-authed `GET /api/apps/[tokenAddress]/entitlements` route. Together they unblock **type-2 durable IAPs** (permanent unlocks, owned levels, story chapters) — purchases that need to survive the user closing the app. Ephemeral type-3 purchases continue to work with `requestPurchase` alone.

## Changes
- `protocol.ts`: 4 new message-type constants + `IapHasItemMessage` / `IapListOwnedMessage` / their result types + 2 type guards.
- `client.ts`: `hasItem(contentId, opts?)` and `getOwnedItems(opts?)`; `AppPaymentsError` code union widens to include `not_authenticated` and `fetch_failed`. Default query timeout is 10s (vs `requestPurchase`'s 5min, since these are non-interactive).
- `index.ts`: re-exports new functions + types.

## Test plan
- [x] 12 new cases (7 `hasItem`, 5 `getOwnedItems`) — well-formed message shape, owned true/false, error code mapping (`not_authenticated`, `fetch_failed`), source-spoof rejection, sync `invalid_input` for non-integer `contentId`, integer-filtering on `getOwnedItems`, timeout, host error.
- [x] Suite 22/22 green (10 pre-existing + 12 new). Biome clean.
- [ ] Manual: build the package, link into the appstore from its sibling PR, run the iframe round-trip end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)