### PR TITLE
feat(app-state): new @elata-biosciences/app-state package

### DIFF
--- a/packages/app-state/README.md
+++ b/packages/app-state/README.md
@@ -1,0 +1,48 @@
+# @elata-biosciences/app-state
+
+Per-user, per-app key-value storage for sandboxed apps in the Elata appstore.
+Lets apps persist save games, settings, progress, and other small JSON blobs
+without standing up their own backend and without ever seeing the user's
+identity.
+
+The host owns the database row scope and the session; this client just sends
+a postMessage to `window.parent` and awaits a typed reply.
+
+## Install
+
+```sh
+npm install @elata-biosciences/app-state
+```
+
+## Usage
+
+```ts
+import { getState, setState, deleteState } from "@elata-biosciences/app-state";
+
+// Read the current save. `null` if nothing was ever stored.
+const save = (await getState("save_slot_1")) as SaveGame | null;
+
+// Persist a new save. JSON-serializable; capped at 64 KB per key on the host.
+await setState("save_slot_1", { level: 7, hp: 100 });
+
+// Remove a key. Idempotent — no error if the key was never set.
+await deleteState("save_slot_1");
+```
+
+All three methods reject with `AppStateError` on failure. The `code` field
+distinguishes local failures (`no_parent`, `timeout`, `invalid_input`) from
+host-reported errors (`not_authenticated`, `value_too_large`, `fetch_failed`).
+
+## Limits
+
+- Keys: 1–256 chars from `A-Z a-z 0-9 . _ : / -`. Pick your own namespace.
+- Values: any JSON-serializable type, ≤ 64 KB once encoded.
+- The host's session model decides who "the user" is — anonymous sessions
+  may exist on some chains; check `error: "not_authenticated"` if your app
+  needs a signed-in user.
+
+## Scope
+
+This package is for **stateful** appstore interactions (save games, settings,
+progress). For payments and entitlements, use
+[`@elata-biosciences/app-payments`](../app-payments).

--- a/packages/app-state/jest.config.cjs
+++ b/packages/app-state/jest.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+	transform: {
+		"^.+\\.tsx?$": ["ts-jest", { diagnostics: false }],
+	},
+	testEnvironment: "jsdom",
+	setupFiles: ["<rootDir>/jest.setup.cjs"],
+	testMatch: ["**/__tests__/**/*.test.ts"],
+	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	collectCoverage: true,
+	collectCoverageFrom: ["src/**/*.ts"],
+	coverageDirectory: "coverage",
+};

--- a/packages/app-state/jest.setup.cjs
+++ b/packages/app-state/jest.setup.cjs
@@ -1,0 +1,13 @@
+// jsdom shims for APIs the client depends on. Production uses native browser
+// implementations.
+//
+// jsdom does provide `globalThis.crypto`, but its older builds lack
+// `randomUUID`. Patch it in either way.
+
+const nodeWebCrypto = require("node:crypto").webcrypto;
+
+if (typeof globalThis.crypto === "undefined") {
+	globalThis.crypto = nodeWebCrypto;
+} else if (typeof globalThis.crypto.randomUUID !== "function") {
+	globalThis.crypto.randomUUID = nodeWebCrypto.randomUUID.bind(nodeWebCrypto);
+}

--- a/packages/app-state/package.json
+++ b/packages/app-state/package.json
@@ -1,0 +1,59 @@
+{
+	"name": "@elata-biosciences/app-state",
+	"version": "0.1.0",
+	"description": "Per-user, per-app state storage for sandboxed apps in the Elata appstore",
+	"license": "MIT",
+	"author": "Elata",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Elata-Biosciences/elata-bio-sdk.git",
+		"directory": "packages/app-state"
+	},
+	"homepage": "https://github.com/Elata-Biosciences/elata-bio-sdk#readme",
+	"bugs": "https://github.com/Elata-Biosciences/elata-bio-sdk/issues",
+	"keywords": [
+		"elata",
+		"appstore",
+		"state",
+		"storage",
+		"sandbox"
+	],
+	"engines": {
+		"node": ">=20"
+	},
+	"type": "module",
+	"sideEffects": false,
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"lint": "pnpm exec biome lint src jest.config.cjs",
+		"test": "jest --config ./jest.config.cjs --passWithNoTests",
+		"test:coverage": "jest --config ./jest.config.cjs --coverage --passWithNoTests",
+		"clean": "node ./scripts/clean.mjs",
+		"build": "tsc -p tsconfig.json && node ./scripts/fix-dist-import-specifiers.mjs && node ./scripts/verify-dist-esm.mjs",
+		"verify:build": "node ../../scripts/verify-package-build.mjs dist/index.js dist/index.d.ts",
+		"verify:publish": "pnpm run verify:build",
+		"prepare:publish": "pnpm run build",
+		"prepack": "pnpm run prepare:publish && pnpm run verify:publish"
+	},
+	"devDependencies": {
+		"@types/jest": "29.5.14",
+		"jest": "29.7.0",
+		"jest-environment-jsdom": "29.7.0",
+		"ts-jest": "29.4.4",
+		"typescript": "5.9.3"
+	}
+}

--- a/packages/app-state/scripts/clean.mjs
+++ b/packages/app-state/scripts/clean.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgDir = path.resolve(__dirname, "..");
+
+const dirs = ["dist", "coverage"];
+const files = ["tsconfig.tsbuildinfo"];
+
+for (const dir of dirs) {
+	const full = path.join(pkgDir, dir);
+	if (fs.existsSync(full)) {
+		fs.rmSync(full, { recursive: true, force: true });
+		console.log("Removed:", dir);
+	}
+}
+for (const file of files) {
+	const full = path.join(pkgDir, file);
+	if (fs.existsSync(full)) {
+		fs.rmSync(full, { force: true });
+		console.log("Removed:", file);
+	}
+}

--- a/packages/app-state/scripts/fix-dist-import-specifiers.mjs
+++ b/packages/app-state/scripts/fix-dist-import-specifiers.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+const distDir = path.join(packageRoot, "dist");
+
+const FILE_EXTENSIONS = new Set([".js", ".d.ts"]);
+const SPECIFIER_PATTERN =
+	/((?:import|export)\s[^'"]*?from\s*|import\s*\(\s*)["'](\.{1,2}\/[^"']+)["']/g;
+
+function shouldAppendJs(specifier) {
+	const ext = path.extname(specifier);
+	return !ext;
+}
+
+function rewriteSpecifiers(contents) {
+	return contents.replace(SPECIFIER_PATTERN, (match, prefix, specifier) => {
+		if (!shouldAppendJs(specifier)) return match;
+		const rewritten = `${specifier}.js`;
+		return `${prefix}"${rewritten}"`;
+	});
+}
+
+function rewriteFile(filePath) {
+	const original = fs.readFileSync(filePath, "utf8");
+	const rewritten = rewriteSpecifiers(original);
+	if (rewritten !== original) {
+		fs.writeFileSync(filePath, rewritten);
+	}
+}
+
+function walk(dir) {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			walk(full);
+			continue;
+		}
+		const ext = path.extname(entry.name);
+		const isDts = entry.name.endsWith(".d.ts");
+		if (FILE_EXTENSIONS.has(ext) || isDts) {
+			rewriteFile(full);
+		}
+	}
+}
+
+if (!fs.existsSync(distDir)) {
+	console.error("dist directory not found:", distDir);
+	process.exit(1);
+}
+
+walk(distDir);

--- a/packages/app-state/scripts/verify-dist-esm.mjs
+++ b/packages/app-state/scripts/verify-dist-esm.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import assert from "node:assert/strict";
+
+const packageRoot = process.cwd();
+const distIndex = path.join(packageRoot, "dist", "index.js");
+
+assert.ok(
+	fs.existsSync(distIndex),
+	"dist/index.js must exist before ESM verification",
+);
+
+const indexSource = fs.readFileSync(distIndex, "utf8");
+assert.match(
+	indexSource,
+	/\.\/client\.js"/,
+	"dist/index.js should re-export client using explicit .js specifier",
+);
+
+console.log("dist ESM specifiers OK");

--- a/packages/app-state/src/__tests__/client.test.ts
+++ b/packages/app-state/src/__tests__/client.test.ts
@@ -1,0 +1,251 @@
+import { AppStateError, deleteState, getState, setState } from "../client";
+import {
+	DELETE_MESSAGE_TYPE,
+	DELETE_RESULT_MESSAGE_TYPE,
+	GET_MESSAGE_TYPE,
+	GET_RESULT_MESSAGE_TYPE,
+	SET_MESSAGE_TYPE,
+	SET_RESULT_MESSAGE_TYPE,
+} from "../protocol";
+
+function buildIframeWindow() {
+	const childListeners: Array<(ev: MessageEvent) => void> = [];
+	const parentMessages: Array<{ data: unknown; targetOrigin: string }> = [];
+
+	const parentWindow = {
+		postMessage: (data: unknown, targetOrigin: string) => {
+			parentMessages.push({ data, targetOrigin });
+		},
+	} as unknown as Window;
+
+	const childWindow = {
+		parent: parentWindow,
+		addEventListener: (type: string, fn: EventListener) => {
+			if (type === "message")
+				childListeners.push(fn as (ev: MessageEvent) => void);
+		},
+		removeEventListener: (type: string, fn: EventListener) => {
+			if (type !== "message") return;
+			const i = childListeners.indexOf(fn as (ev: MessageEvent) => void);
+			if (i >= 0) childListeners.splice(i, 1);
+		},
+	} as unknown as Window;
+
+	const replyFromParent = (payload: unknown) => {
+		const event = {
+			data: payload,
+			source: parentWindow,
+			origin: "https://appstore.example",
+		} as unknown as MessageEvent;
+		for (const fn of [...childListeners]) fn(event);
+	};
+
+	const replyFromOther = (payload: unknown) => {
+		const event = {
+			data: payload,
+			source: {} as Window,
+			origin: "https://evil.example",
+		} as unknown as MessageEvent;
+		for (const fn of [...childListeners]) fn(event);
+	};
+
+	return {
+		childWindow,
+		parentMessages,
+		replyFromParent,
+		replyFromOther,
+		listenerCount: () => childListeners.length,
+	};
+}
+
+describe("getState", () => {
+	it("posts a well-formed elata:state:get to the parent", async () => {
+		const fx = buildIframeWindow();
+		const promise = getState("save_1", { window: fx.childWindow });
+
+		expect(fx.parentMessages).toHaveLength(1);
+		const msg = fx.parentMessages[0].data as Record<string, unknown>;
+		expect(msg.type).toBe(GET_MESSAGE_TYPE);
+		expect(msg.key).toBe("save_1");
+		expect(typeof msg.requestId).toBe("string");
+
+		fx.replyFromParent({
+			type: GET_RESULT_MESSAGE_TYPE,
+			requestId: msg.requestId,
+			value: null,
+		});
+		await promise;
+	});
+
+	it("resolves with the host-supplied value", async () => {
+		const fx = buildIframeWindow();
+		const promise = getState("save_1", { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({
+			type: GET_RESULT_MESSAGE_TYPE,
+			requestId,
+			value: { level: 7 },
+		});
+		await expect(promise).resolves.toEqual({ level: 7 });
+	});
+
+	it("resolves with null when the host returns no value field", async () => {
+		const fx = buildIframeWindow();
+		const promise = getState("save_1", { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({ type: GET_RESULT_MESSAGE_TYPE, requestId });
+		await expect(promise).resolves.toBeNull();
+	});
+
+	it("rejects with not_authenticated", async () => {
+		const fx = buildIframeWindow();
+		const promise = getState("save_1", { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({
+			type: GET_RESULT_MESSAGE_TYPE,
+			requestId,
+			error: "not_authenticated",
+		});
+		await expect(promise).rejects.toMatchObject({
+			name: "AppStateError",
+			code: "not_authenticated",
+		});
+	});
+
+	it("rejects synchronously when key is empty or too long", () => {
+		const fx = buildIframeWindow();
+		expect(() => getState("", { window: fx.childWindow })).toThrow(AppStateError);
+		expect(() =>
+			getState("x".repeat(257), { window: fx.childWindow }),
+		).toThrow(AppStateError);
+	});
+
+	it("rejects with timeout when no result arrives", async () => {
+		const fx = buildIframeWindow();
+		const promise = getState("save_1", { window: fx.childWindow, timeoutMs: 10 });
+		await expect(promise).rejects.toMatchObject({ code: "timeout" });
+		expect(fx.listenerCount()).toBe(0);
+	});
+
+	it("ignores results from a non-parent source", async () => {
+		const fx = buildIframeWindow();
+		const promise = getState("save_1", { window: fx.childWindow, timeoutMs: 30 });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromOther({
+			type: GET_RESULT_MESSAGE_TYPE,
+			requestId,
+			value: "spoofed",
+		});
+		await expect(promise).rejects.toMatchObject({ code: "timeout" });
+	});
+});
+
+describe("setState", () => {
+	it("posts a well-formed elata:state:set including the value", async () => {
+		const fx = buildIframeWindow();
+		const promise = setState("save_1", { level: 8 }, { window: fx.childWindow });
+		const msg = fx.parentMessages[0].data as Record<string, unknown>;
+		expect(msg.type).toBe(SET_MESSAGE_TYPE);
+		expect(msg.key).toBe("save_1");
+		expect(msg.value).toEqual({ level: 8 });
+		fx.replyFromParent({
+			type: SET_RESULT_MESSAGE_TYPE,
+			requestId: msg.requestId as string,
+			ok: true,
+		});
+		await promise;
+	});
+
+	it("resolves void on success", async () => {
+		const fx = buildIframeWindow();
+		const promise = setState("save_1", 1, { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({ type: SET_RESULT_MESSAGE_TYPE, requestId, ok: true });
+		await expect(promise).resolves.toBeUndefined();
+	});
+
+	it("rejects with value_too_large on host error", async () => {
+		const fx = buildIframeWindow();
+		const promise = setState("save_1", "x", { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({
+			type: SET_RESULT_MESSAGE_TYPE,
+			requestId,
+			error: "value_too_large",
+		});
+		await expect(promise).rejects.toMatchObject({ code: "value_too_large" });
+	});
+
+	it("rejects synchronously when value is undefined", () => {
+		const fx = buildIframeWindow();
+		expect(() =>
+			setState("save_1", undefined, { window: fx.childWindow }),
+		).toThrow(AppStateError);
+	});
+
+	it("rejects synchronously when called outside an iframe", () => {
+		const sameWindow = {} as Window;
+		(sameWindow as { parent: Window }).parent = sameWindow;
+		expect(() => setState("save_1", 1, { window: sameWindow })).toThrow(
+			AppStateError,
+		);
+	});
+});
+
+describe("deleteState", () => {
+	it("posts a well-formed elata:state:delete", async () => {
+		const fx = buildIframeWindow();
+		const promise = deleteState("save_1", { window: fx.childWindow });
+		const msg = fx.parentMessages[0].data as Record<string, unknown>;
+		expect(msg.type).toBe(DELETE_MESSAGE_TYPE);
+		expect(msg.key).toBe("save_1");
+		fx.replyFromParent({
+			type: DELETE_RESULT_MESSAGE_TYPE,
+			requestId: msg.requestId as string,
+			ok: true,
+		});
+		await promise;
+	});
+
+	it("resolves void on success", async () => {
+		const fx = buildIframeWindow();
+		const promise = deleteState("save_1", { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({
+			type: DELETE_RESULT_MESSAGE_TYPE,
+			requestId,
+			ok: true,
+		});
+		await expect(promise).resolves.toBeUndefined();
+	});
+
+	it("rejects with fetch_failed on unknown host error", async () => {
+		const fx = buildIframeWindow();
+		const promise = deleteState("save_1", { window: fx.childWindow });
+		const requestId = (fx.parentMessages[0].data as { requestId: string })
+			.requestId;
+		fx.replyFromParent({
+			type: DELETE_RESULT_MESSAGE_TYPE,
+			requestId,
+			error: "anything_else",
+		});
+		await expect(promise).rejects.toMatchObject({ code: "fetch_failed" });
+	});
+
+	it("rejects with timeout when no result arrives", async () => {
+		const fx = buildIframeWindow();
+		const promise = deleteState("save_1", {
+			window: fx.childWindow,
+			timeoutMs: 10,
+		});
+		await expect(promise).rejects.toMatchObject({ code: "timeout" });
+		expect(fx.listenerCount()).toBe(0);
+	});
+});

--- a/packages/app-state/src/client.ts
+++ b/packages/app-state/src/client.ts
@@ -1,0 +1,367 @@
+/**
+ * Per-user, per-app key-value storage for sandboxed apps. Three methods:
+ * `getState`, `setState`, `deleteState`. Each generates a `requestId`,
+ * posts to `window.parent`, awaits a matching `:result` message, and
+ * resolves.
+ *
+ * The host owns the database row scope and the session — this client never
+ * sees the user's identity. Mirrors the postMessage round-trip / promise /
+ * timeout pattern of `@elata-biosciences/app-payments`.
+ */
+
+import {
+	DELETE_MESSAGE_TYPE,
+	GET_MESSAGE_TYPE,
+	KEY_MAX_LENGTH,
+	REQUEST_ID_MAX_LENGTH,
+	REQUEST_ID_MIN_LENGTH,
+	SET_MESSAGE_TYPE,
+	type StateDeleteMessage,
+	type StateGetMessage,
+	type StateSetMessage,
+	isStateDeleteResultMessage,
+	isStateGetResultMessage,
+	isStateSetResultMessage,
+} from "./protocol";
+
+export type AppStateErrorCode =
+	| "no_window"
+	| "no_parent"
+	| "invalid_input"
+	| "timeout"
+	| "no_crypto"
+	| "not_authenticated"
+	| "value_too_large"
+	| "not_found"
+	| "fetch_failed";
+
+export class AppStateError extends Error {
+	readonly code: AppStateErrorCode;
+	constructor(code: AppStateErrorCode, message: string) {
+		super(message);
+		this.name = "AppStateError";
+		this.code = code;
+	}
+}
+
+export interface StateOptions {
+	/** Default 10 seconds. Pass `Infinity` to wait forever. */
+	timeoutMs?: number;
+	/** Optional override for testing. Defaults to the global `window`. */
+	window?: Window;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function generateRequestId(): string {
+	const c = globalThis.crypto;
+	if (!c || typeof c.randomUUID !== "function") {
+		throw new AppStateError(
+			"no_crypto",
+			"crypto.randomUUID not available in this environment",
+		);
+	}
+	const id = c.randomUUID();
+	if (id.length < REQUEST_ID_MIN_LENGTH || id.length > REQUEST_ID_MAX_LENGTH) {
+		throw new AppStateError(
+			"invalid_input",
+			`generated requestId outside host bounds [${REQUEST_ID_MIN_LENGTH}, ${REQUEST_ID_MAX_LENGTH}]`,
+		);
+	}
+	return id;
+}
+
+function resolveParent(targetWindow: Window | undefined): {
+	targetWindow: Window;
+	parent: Window;
+} {
+	const tw = targetWindow ?? globalThis.window;
+	if (!tw) {
+		throw new AppStateError(
+			"no_window",
+			"no window available (call state methods in a browser context)",
+		);
+	}
+	const parent = tw.parent;
+	if (!parent || parent === tw) {
+		throw new AppStateError(
+			"no_parent",
+			"state methods must run inside an iframe with an appstore parent",
+		);
+	}
+	return { targetWindow: tw, parent };
+}
+
+function validateKey(key: unknown): asserts key is string {
+	if (
+		typeof key !== "string" ||
+		key.length === 0 ||
+		key.length > KEY_MAX_LENGTH
+	) {
+		throw new AppStateError(
+			"invalid_input",
+			`key must be a non-empty string of at most ${KEY_MAX_LENGTH} characters`,
+		);
+	}
+}
+
+function mapErrorCode(raw: string | undefined): AppStateErrorCode {
+	switch (raw) {
+		case "not_authenticated":
+			return "not_authenticated";
+		case "invalid_input":
+			return "invalid_input";
+		case "value_too_large":
+			return "value_too_large";
+		case "not_found":
+			return "not_found";
+		default:
+			return "fetch_failed";
+	}
+}
+
+/**
+ * Read the value stored under `key` for the current session user. Resolves
+ * with `null` if no value is set, the parsed JSON value otherwise.
+ *
+ * Throws `AppStateError` on local failures (`no_parent`, `timeout`,
+ * `invalid_input`) and host-reported errors (`not_authenticated`,
+ * `fetch_failed`).
+ *
+ * @example
+ *   const save = await getState("save_slot_1") as SaveGame | null;
+ */
+export function getState(
+	key: string,
+	opts: StateOptions = {},
+): Promise<unknown> {
+	validateKey(key);
+	if (opts.timeoutMs !== undefined && typeof opts.timeoutMs !== "number") {
+		throw new AppStateError("invalid_input", "timeoutMs must be a number");
+	}
+	const { targetWindow, parent } = resolveParent(opts.window);
+	const requestId = generateRequestId();
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	const message: StateGetMessage = {
+		type: GET_MESSAGE_TYPE,
+		requestId,
+		key,
+	};
+
+	return new Promise<unknown>((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const cleanup = () => {
+			targetWindow.removeEventListener("message", onMessage);
+			if (timer !== null) clearTimeout(timer);
+		};
+		const settle = (value: unknown) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(value);
+		};
+		const fail = (err: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(err);
+		};
+		const onMessage = (ev: MessageEvent<unknown>) => {
+			if (ev.source !== parent) return;
+			if (!isStateGetResultMessage(ev.data)) return;
+			if (ev.data.requestId !== requestId) return;
+			if (typeof ev.data.error === "string") {
+				fail(new AppStateError(mapErrorCode(ev.data.error), ev.data.error));
+				return;
+			}
+			settle(ev.data.value ?? null);
+		};
+		targetWindow.addEventListener("message", onMessage);
+		if (timeoutMs !== Number.POSITIVE_INFINITY) {
+			timer = setTimeout(() => {
+				fail(
+					new AppStateError(
+						"timeout",
+						`no getState result within ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+		}
+		try {
+			parent.postMessage(message, "*");
+		} catch (e) {
+			fail(
+				new AppStateError(
+					"invalid_input",
+					e instanceof Error ? e.message : "postMessage failed",
+				),
+			);
+		}
+	});
+}
+
+/**
+ * Upsert `value` (any JSON-serializable type) under `key` for the current
+ * session user. The host caps the encoded value at 64 KB.
+ *
+ * @example
+ *   await setState("save_slot_1", { level: 7, hp: 100 });
+ */
+export function setState(
+	key: string,
+	value: unknown,
+	opts: StateOptions = {},
+): Promise<void> {
+	validateKey(key);
+	if (opts.timeoutMs !== undefined && typeof opts.timeoutMs !== "number") {
+		throw new AppStateError("invalid_input", "timeoutMs must be a number");
+	}
+	if (typeof value === "function" || typeof value === "undefined") {
+		throw new AppStateError(
+			"invalid_input",
+			"value must be JSON-serializable (not undefined or a function)",
+		);
+	}
+	const { targetWindow, parent } = resolveParent(opts.window);
+	const requestId = generateRequestId();
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	const message: StateSetMessage = {
+		type: SET_MESSAGE_TYPE,
+		requestId,
+		key,
+		value,
+	};
+
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const cleanup = () => {
+			targetWindow.removeEventListener("message", onMessage);
+			if (timer !== null) clearTimeout(timer);
+		};
+		const settle = () => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve();
+		};
+		const fail = (err: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(err);
+		};
+		const onMessage = (ev: MessageEvent<unknown>) => {
+			if (ev.source !== parent) return;
+			if (!isStateSetResultMessage(ev.data)) return;
+			if (ev.data.requestId !== requestId) return;
+			if (typeof ev.data.error === "string") {
+				fail(new AppStateError(mapErrorCode(ev.data.error), ev.data.error));
+				return;
+			}
+			settle();
+		};
+		targetWindow.addEventListener("message", onMessage);
+		if (timeoutMs !== Number.POSITIVE_INFINITY) {
+			timer = setTimeout(() => {
+				fail(
+					new AppStateError(
+						"timeout",
+						`no setState result within ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+		}
+		try {
+			parent.postMessage(message, "*");
+		} catch (e) {
+			fail(
+				new AppStateError(
+					"invalid_input",
+					e instanceof Error ? e.message : "postMessage failed",
+				),
+			);
+		}
+	});
+}
+
+/**
+ * Remove the value stored under `key`. Idempotent — resolves successfully
+ * even if no value was set.
+ *
+ * @example
+ *   await deleteState("save_slot_1");
+ */
+export function deleteState(
+	key: string,
+	opts: StateOptions = {},
+): Promise<void> {
+	validateKey(key);
+	if (opts.timeoutMs !== undefined && typeof opts.timeoutMs !== "number") {
+		throw new AppStateError("invalid_input", "timeoutMs must be a number");
+	}
+	const { targetWindow, parent } = resolveParent(opts.window);
+	const requestId = generateRequestId();
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+	const message: StateDeleteMessage = {
+		type: DELETE_MESSAGE_TYPE,
+		requestId,
+		key,
+	};
+
+	return new Promise<void>((resolve, reject) => {
+		let settled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const cleanup = () => {
+			targetWindow.removeEventListener("message", onMessage);
+			if (timer !== null) clearTimeout(timer);
+		};
+		const settle = () => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve();
+		};
+		const fail = (err: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			reject(err);
+		};
+		const onMessage = (ev: MessageEvent<unknown>) => {
+			if (ev.source !== parent) return;
+			if (!isStateDeleteResultMessage(ev.data)) return;
+			if (ev.data.requestId !== requestId) return;
+			if (typeof ev.data.error === "string") {
+				fail(new AppStateError(mapErrorCode(ev.data.error), ev.data.error));
+				return;
+			}
+			settle();
+		};
+		targetWindow.addEventListener("message", onMessage);
+		if (timeoutMs !== Number.POSITIVE_INFINITY) {
+			timer = setTimeout(() => {
+				fail(
+					new AppStateError(
+						"timeout",
+						`no deleteState result within ${timeoutMs}ms`,
+					),
+				);
+			}, timeoutMs);
+		}
+		try {
+			parent.postMessage(message, "*");
+		} catch (e) {
+			fail(
+				new AppStateError(
+					"invalid_input",
+					e instanceof Error ? e.message : "postMessage failed",
+				),
+			);
+		}
+	});
+}

--- a/packages/app-state/src/index.ts
+++ b/packages/app-state/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Public API for sandboxed apps. The appstore host has its own listener
+ * inside the parent frame; apps do not import anything from this package
+ * to handle responses — they `await getState(...)` / `setState(...)` /
+ * `deleteState(...)`.
+ */
+
+export {
+	AppStateError,
+	deleteState,
+	getState,
+	setState,
+} from "./client";
+export type { AppStateErrorCode, StateOptions } from "./client";

--- a/packages/app-state/src/protocol.ts
+++ b/packages/app-state/src/protocol.ts
@@ -1,0 +1,99 @@
+/**
+ * Wire protocol between the sandboxed app (client) and the appstore host
+ * for per-user, per-app key-value storage. Mirrors the request/response
+ * postMessage pattern used by `@elata-biosciences/app-payments`.
+ *
+ * The app sends `elata:state:get` / `elata:state:set` / `elata:state:delete`
+ * to `window.parent`. The host validates `event.origin === embedOrigin`,
+ * fetches the matching session-authed route on the app's behalf, and
+ * replies with an `:result` message keyed by `requestId`.
+ */
+
+export const PROTOCOL_VERSION = 1 as const;
+
+export const GET_MESSAGE_TYPE = "elata:state:get" as const;
+export const GET_RESULT_MESSAGE_TYPE = "elata:state:get:result" as const;
+export const SET_MESSAGE_TYPE = "elata:state:set" as const;
+export const SET_RESULT_MESSAGE_TYPE = "elata:state:set:result" as const;
+export const DELETE_MESSAGE_TYPE = "elata:state:delete" as const;
+export const DELETE_RESULT_MESSAGE_TYPE = "elata:state:delete:result" as const;
+
+/** Host-enforced bounds on `requestId` length. Mirror these on the client. */
+export const REQUEST_ID_MIN_LENGTH = 8;
+export const REQUEST_ID_MAX_LENGTH = 128;
+
+/** Host-enforced bounds on `key` length. Charset is enforced on the host. */
+export const KEY_MAX_LENGTH = 256;
+
+export interface StateGetMessage {
+	type: typeof GET_MESSAGE_TYPE;
+	requestId: string;
+	key: string;
+}
+
+export interface StateGetResultMessage {
+	type: typeof GET_RESULT_MESSAGE_TYPE;
+	requestId: string;
+	/** Present on success. `null` if the key does not exist. */
+	value?: unknown;
+	/** Present on failure. Codes: `not_authenticated`, `invalid_input`, `fetch_failed`. */
+	error?: string;
+}
+
+export interface StateSetMessage {
+	type: typeof SET_MESSAGE_TYPE;
+	requestId: string;
+	key: string;
+	value: unknown;
+}
+
+export interface StateSetResultMessage {
+	type: typeof SET_RESULT_MESSAGE_TYPE;
+	requestId: string;
+	ok?: true;
+	/** Codes: `not_authenticated`, `invalid_input`, `value_too_large`, `fetch_failed`. */
+	error?: string;
+}
+
+export interface StateDeleteMessage {
+	type: typeof DELETE_MESSAGE_TYPE;
+	requestId: string;
+	key: string;
+}
+
+export interface StateDeleteResultMessage {
+	type: typeof DELETE_RESULT_MESSAGE_TYPE;
+	requestId: string;
+	ok?: true;
+	error?: string;
+}
+
+export function isStateGetResultMessage(
+	value: unknown,
+): value is StateGetResultMessage {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.type !== GET_RESULT_MESSAGE_TYPE) return false;
+	if (typeof v.requestId !== "string") return false;
+	return true;
+}
+
+export function isStateSetResultMessage(
+	value: unknown,
+): value is StateSetResultMessage {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.type !== SET_RESULT_MESSAGE_TYPE) return false;
+	if (typeof v.requestId !== "string") return false;
+	return true;
+}
+
+export function isStateDeleteResultMessage(
+	value: unknown,
+): value is StateDeleteResultMessage {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	if (v.type !== DELETE_RESULT_MESSAGE_TYPE) return false;
+	if (typeof v.requestId !== "string") return false;
+	return true;
+}

--- a/packages/app-state/tsconfig.json
+++ b/packages/app-state/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ES2020",
+		"lib": ["ES2020", "DOM"],
+		"moduleResolution": "Bundler",
+		"rootDir": "src",
+		"outDir": "dist",
+		"declaration": true,
+		"declarationMap": true,
+		"composite": true,
+		"strict": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/__tests__/**", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,24 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  packages/app-state:
+    devDependencies:
+      '@types/jest':
+        specifier: 29.5.14
+        version: 29.5.14
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@25.3.3)
+      jest-environment-jsdom:
+        specifier: 29.7.0
+        version: 29.7.0
+      ts-jest:
+        specifier: 29.4.4
+        version: 29.4.4(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.2.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.25.10)(jest-util@30.2.0)(jest@29.7.0(@types/node@25.3.3))(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/create-elata-demo: {}
 
   packages/eeg-web:


### PR DESCRIPTION
## Summary
New SDK package: \`@elata-biosciences/app-state\` (0.1.0). Per-user, per-app key-value storage for sandboxed apps.

\`\`\`ts
import { getState, setState, deleteState } from "@elata-biosciences/app-state";

const save = (await getState("save_slot_1")) as SaveGame | null;
await setState("save_slot_1", { level: 8, hp: 75 });
await deleteState("save_slot_1");
\`\`\`

## Why a new package
The proxy pattern stopped being just-IAP. Apps that only need payments still install \`@elata-biosciences/app-payments\`; apps that only need state install this; apps that need both install both. A future broader package may absorb both — but that decision can wait until we have more primitives (scores, leaderboards, etc.).

## Shape
Mirrors \`app-payments\`:
- postMessage round-trip with requestId-keyed reply
- \`AppStateError\` with \`code\` field (\`no_parent\`, \`timeout\`, \`invalid_input\`, \`not_authenticated\`, \`value_too_large\`, \`fetch_failed\`, etc.)
- Default 10s timeout
- Same scripts (\`build\`, \`clean\`, \`verify:build\`, \`prepack\`), jest config, tsconfig

## Pairs with
Appstore PR Elata-Biosciences/elata-appstore#TBD which adds the matching route + PlayHeader handler.

## Test plan
- [x] 16 cases — well-formed message shape, value returned, null on missing, error code mapping, sync validation (empty / too-long key, undefined value, called outside iframe), timeout.
- [x] Suite passes; \`pnpm build\` succeeds; Biome clean.
- [ ] Manual: publish 0.1.0, link into the appstore PR, exercise round-trip end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)