### PR TITLE
docs(app-payments): full API docs + IAP guide; bump to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Use this quick guide if you are starting from an existing app:
 | Run EEG WASM APIs in the browser | [`@elata-biosciences/eeg-web`](https://www.npmjs.com/package/@elata-biosciences/eeg-web) | Signal processing, models, and WASM helpers |
 | Connect to an EEG headset over Web Bluetooth in the browser | [`@elata-biosciences/eeg-web-ble`](https://www.npmjs.com/package/@elata-biosciences/eeg-web-ble) | Requires `@elata-biosciences/eeg-web` and Web Bluetooth; Muse built-in; [extend for other headsets](docs/contributing-eeg-transports.md) |
 | Run camera-based rPPG in a browser app | [`@elata-biosciences/rppg-web`](https://www.npmjs.com/package/@elata-biosciences/rppg-web) | Includes processor, backend loader, and demo helpers |
+| Add in-app purchases to an appstore app | [`@elata-biosciences/app-payments`](https://www.npmjs.com/package/@elata-biosciences/app-payments) | Purchases + entitlements over `postMessage`; see [guide](docs/guides/using-iap-in-a-browser-app.md) and [demo](examples/iap-demo) |
 
 If you are trying the SDK for the first time, prefer `create-elata-demo` over
 manual package setup.
@@ -121,6 +122,7 @@ Scope overview: [@elata-biosciences on npm](https://www.npmjs.com/org/elata-bios
 - [@elata-biosciences/eeg-web](https://www.npmjs.com/package/@elata-biosciences/eeg-web): EEG WASM wrapper and re-export surface
 - [@elata-biosciences/eeg-web-ble](https://www.npmjs.com/package/@elata-biosciences/eeg-web-ble): Web Bluetooth transport for EEG headbands (Muse built-in; [contributor extensions](docs/contributing-eeg-transports.md))
 - [@elata-biosciences/rppg-web](https://www.npmjs.com/package/@elata-biosciences/rppg-web): rPPG processing wrapper and demo helpers
+- [@elata-biosciences/app-payments](https://www.npmjs.com/package/@elata-biosciences/app-payments): in-app purchases and entitlements for sandboxed appstore apps
 - [@elata-biosciences/create-elata-demo](https://www.npmjs.com/package/@elata-biosciences/create-elata-demo): app scaffolder with multiple templates
 
 ## Compatibility Summary

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -9,5 +9,6 @@ These guides are aimed at SDK consumers rather than repo maintainers.
 - [using-eeg-in-a-browser-app.md](using-eeg-in-a-browser-app.md): integrate EEG WASM APIs into a browser app
 - [using-web-bluetooth-with-supported-devices.md](using-web-bluetooth-with-supported-devices.md): Web Bluetooth headset flow in the browser (Muse built-in today)
 - [using-rppg-in-a-browser-app.md](using-rppg-in-a-browser-app.md): integrate browser-side rPPG processing
+- [using-iap-in-a-browser-app.md](using-iap-in-a-browser-app.md): add in-app purchases to an app running in the Elata appstore
 - [compatibility.md](compatibility.md): browser, device, Node, and package-manager expectations
 - [troubleshooting.md](troubleshooting.md): common setup and runtime failures

--- a/docs/guides/example-apps.md
+++ b/docs/guides/example-apps.md
@@ -65,3 +65,4 @@ dimensions where applicable, and **compressed WebP derivatives** (`preview-deskt
 - [getting-started.md](getting-started.md)
 - [using-eeg-in-a-browser-app.md](using-eeg-in-a-browser-app.md)
 - [using-rppg-in-a-browser-app.md](using-rppg-in-a-browser-app.md)
+- [using-iap-in-a-browser-app.md](using-iap-in-a-browser-app.md)

--- a/docs/guides/using-iap-in-a-browser-app.md
+++ b/docs/guides/using-iap-in-a-browser-app.md
@@ -1,0 +1,145 @@
+# Using IAP In A Browser App
+
+How to add in-app purchases to an app that runs in the Elata appstore, using
+`@elata-biosciences/app-payments`. Your app runs in a sandboxed iframe with no
+wallet or session access — it talks to the appstore host over `postMessage`, and
+this package wraps that protocol.
+
+## Start With The Fastest Path
+
+If you want a working reference before integrating manually, clone the demo. It
+is one self-contained file that runs standalone via a built-in mock host:
+
+```bash
+git clone https://github.com/Elata-Biosciences/elata-bio-sdk
+cd elata-bio-sdk/examples/iap-demo
+npx serve .   # or open index.html directly
+```
+
+It exercises the whole flow — catalog, ownership-gated UI, purchase (success /
+cancel / error), and an applied, reload-persisted benefit. Use this guide when
+you want to add purchasing to an existing app.
+
+## Install
+
+```bash
+pnpm add @elata-biosciences/app-payments
+npm install @elata-biosciences/app-payments
+```
+
+## What `app-payments` Gives You
+
+`@elata-biosciences/app-payments` exports four functions and one error type:
+
+- `requestPurchase()` — start a purchase; the host opens checkout and settles it
+- `getOwnedItems()` — list every `contentId` the user owns for this app
+- `hasItem(contentId)` — check ownership of a single item
+- `getCatalog()` — list the app's active items (price/title/description)
+- `AppPaymentsError` — thrown for local/host failures (`.code`)
+
+The host owns the wallet, payment modal, on-chain verification, and entitlement
+records. Your app declares intent and reads results.
+
+## The Two Rules People Get Wrong
+
+1. **Gate the UI on ownership.** Before showing a "Buy" button, ask the host
+   what the user already owns and adapt — owned items show "Use", unowned show
+   "Buy". Skip this and an owner sees a Buy button that dead-ends at "you already
+   own this" with no way to *use* what they paid for.
+2. **Branch on `result.status`, never on `txHash`.** When the user already owns
+   the item, the host returns `success` with an **empty `txHash`**. Keying off
+   `if (result.txHash)` mishandles the already-owned case.
+
+## Minimal Integration
+
+```ts
+import {
+  getCatalog,
+  getOwnedItems,
+  requestPurchase,
+  AppPaymentsError,
+} from "@elata-biosciences/app-payments";
+
+const [items, owned] = await Promise.all([getCatalog(), getOwnedItems()]);
+const ownedSet = new Set(owned);
+
+async function buy(item) {
+  try {
+    const result = await requestPurchase({
+      contentId: item.contentId,
+      title: item.title,
+      priceUsdc: `$${(Number(item.priceUsdc) / 1e6).toFixed(2)}`, // display hint
+    });
+    if (result.status === "success") {
+      ownedSet.add(item.contentId);
+      applyBenefit(item.contentId); // your app decides what owning it does
+    } else if (result.status === "error") {
+      showError(result.error);
+    } // "cancelled" → no-op
+  } catch (err) {
+    showError(err instanceof AppPaymentsError ? `${err.code}: ${err.message}` : String(err));
+  }
+}
+
+// On startup, re-derive ownership and re-apply — the host is the source of
+// truth, so benefits survive reloads with no local persistence.
+for (const id of owned) applyBenefit(id);
+```
+
+## Typical Integration Flow
+
+1. On mount, call `getCatalog()` and `getOwnedItems()`.
+2. Render owned items as "Use", unowned as "Buy".
+3. On Buy, call `requestPurchase()` and handle all three result branches.
+4. On `success`, grant the effect immediately and re-render.
+5. On reload, re-read ownership and re-apply — don't trust local state alone.
+
+## Price Units
+
+`CatalogItem.priceUsdc` is **USDC base units** (6 decimals): `"50000"` is `$0.05`.
+Format it for display with `(Number(p) / 1e6).toFixed(2)`. The `priceUsdc` you
+pass to `requestPurchase` is a **free-form display hint** the SDK does not
+interpret and the host overrides — pass the formatted string.
+
+## Host Support And Graceful Degradation
+
+`getCatalog` and `requestPurchase` are handled by the live host today. The
+ownership queries (`getOwnedItems` / `hasItem`) require the appstore's offchain
+entitlement handlers ([appstore PR #472](https://github.com/Elata-Biosciences/elata-appstore/pull/472)).
+Until that ships, those calls **time out** against the live host. Don't
+dead-end — use a short `timeoutMs` and fall back to showing items as available:
+
+```ts
+let ownedSet;
+try {
+  ownedSet = new Set(await getOwnedItems({ timeoutMs: 4000 }));
+} catch (err) {
+  if (err instanceof AppPaymentsError && err.code === "timeout") ownedSet = new Set();
+  else throw err;
+}
+```
+
+## Common Gotchas
+
+- **`no_parent` thrown:** you're not inside an appstore iframe. The SDK posts to
+  `window.parent`; run it embedded, or pass a mock `window` for local dev (see
+  the demo's mock host).
+- **Empty `txHash` on success:** that's the already-owned short-circuit, not a
+  bug. Branch on `status`.
+- **Repeat purchases:** the server does not enforce single-ownership; the
+  checkout UI soft-blocks re-buying an owned item. You cannot build a "spend each
+  run" consumable on one `contentId` today.
+- **`getCatalog` missing from an older install:** it shipped after npm `0.2.0`.
+  Use `>= 0.3.0`, or feature-detect with a namespace import.
+
+## Version Guidance
+
+Use `@elata-biosciences/app-payments` `>= 0.3.0` for `getCatalog`. The package is
+`0.x` and the wire protocol is `v1`; breaking protocol changes bump both.
+
+## Next Steps
+
+- For the full API, see [packages/app-payments/README.md](../../packages/app-payments/README.md).
+- For the runnable reference, see [examples/iap-demo](../../examples/iap-demo).
+- For platform/host details and the product model, see `IAP_SDK_INTEGRATION.md`
+  in the appstore repo.

--- a/packages/app-payments/README.md
+++ b/packages/app-payments/README.md
@@ -2,7 +2,7 @@
 
 In-app purchases for sandboxed apps running in the [Elata appstore](https://github.com/Elata-Biosciences/elata-appstore).
 
-The appstore renders apps inside a sandboxed iframe with no wallet or backend access. This package lets the app request a purchase from the parent frame, which owns the payment UI (PayEmbed, wallet, on-chain settlement). The app just declares intent and awaits the verdict.
+The appstore renders apps inside a sandboxed iframe with no wallet or backend access. This package lets the app **request a purchase** from the parent frame and **read what the user owns**, all over `postMessage`. The parent owns the payment UI (PayEmbed, wallet, on-chain settlement) and the session. Your app declares intent and reads entitlements; it never touches wallets, USDC, or transaction signing.
 
 ## Install
 
@@ -10,61 +10,198 @@ The appstore renders apps inside a sandboxed iframe with no wallet or backend ac
 pnpm add @elata-biosciences/app-payments
 ```
 
-## Usage
+## The API surface
 
 ```ts
-import { requestPurchase } from "@elata-biosciences/app-payments";
+import {
+  requestPurchase,
+  hasItem,
+  getOwnedItems,
+  getCatalog,
+  AppPaymentsError,
+} from "@elata-biosciences/app-payments";
+```
 
-async function onChickenStand() {
-  const result = await requestPurchase({
-    contentId: 7,           // issued by the host when the listing was created
-    priceUsdc: "0.01",      // display hint — host refetches the authoritative price
-    title: "Chicken",
-    description: "Unlocks the next level.",
-  });
+| Function | Signature | Returns | Use it to |
+|----------|-----------|---------|-----------|
+| `requestPurchase` | `(input: RequestPurchaseInput)` | `Promise<PurchaseResult>` | Start a purchase; opens the host checkout |
+| `hasItem` | `(contentId: number, opts?)` | `Promise<boolean>` | Check whether the user owns one item |
+| `getOwnedItems` | `(opts?)` | `Promise<number[]>` | List every owned `contentId` (sorted) |
+| `getCatalog` | `(opts?)` | `Promise<CatalogItem[]>` | List the app's items (price/title/desc) |
 
-  switch (result.status) {
-    case "success":
-      unlockNextLevel();
-      console.log("paid in tx", result.txHash);
-      break;
-    case "cancelled":
-      // user closed the modal — leave them where they are
-      break;
-    case "error":
-      showError(result.error);
-      break;
+You are responsible for exactly two things: **read entitlements to decide what to show**, and **react to the purchase result** (grant the benefit on success; handle cancel/error gracefully). The host does everything else.
+
+## The correct flow
+
+Don't call `requestPurchase` in isolation. Gate the UI on ownership first, then purchase, then apply and persist the benefit:
+
+```ts
+import {
+  getCatalog,
+  getOwnedItems,
+  requestPurchase,
+  AppPaymentsError,
+} from "@elata-biosciences/app-payments";
+
+// 1. Read the catalog and what the user already owns.
+const [items, owned] = await Promise.all([getCatalog(), getOwnedItems()]);
+const ownedSet = new Set(owned);
+
+// 2. Render: owned items show "Use", unowned show "Buy".
+function render() {
+  for (const item of items) {
+    const isOwned = ownedSet.has(item.contentId);
+    // isOwned ? showUse(item) : showBuy(item)
   }
+}
+
+// 3. Buy. Branch on result.status.
+async function buy(item) {
+  try {
+    const result = await requestPurchase({
+      contentId: item.contentId,
+      priceUsdc: formatUsdc(item.priceUsdc), // display hint only (see below)
+      title: item.title,
+      description: item.description ?? undefined,
+    });
+    switch (result.status) {
+      case "success":
+        ownedSet.add(item.contentId);
+        applyBenefit(item.contentId); // 4. grant the effect now…
+        render();
+        break;
+      case "cancelled":
+        break; // user backed out before paying — no-op
+      case "error":
+        showError(result.error);
+        break;
+    }
+  } catch (err) {
+    // Thrown only for SDK-level problems (no parent, bad input, timeout).
+    showError(err instanceof AppPaymentsError ? `${err.code}: ${err.message}` : String(err));
+  }
+}
+
+// 5. On startup, re-derive ownership and re-apply — the host is the source of
+// truth, so the benefit survives reloads without any local persistence.
+for (const id of owned) applyBenefit(id);
+```
+
+`requestPurchase` records *that* the user owns an item. **Your app** decides what owning it *does* — the `applyBenefit` step is the part that's actually a feature.
+
+## Purchasing
+
+`RequestPurchaseInput`:
+
+```ts
+{ contentId: number; priceUsdc?: string; title?: string; description?: string; timeoutMs?: number }
+```
+
+`priceUsdc` / `title` / `description` are **display hints only** — the host refetches the authoritative listing and overrides them. `requestPurchase` defaults to a **5-minute** timeout.
+
+`PurchaseResult` is a discriminated union — branch on `status`:
+
+```ts
+{ status: "success",   requestId: string, txHash: string }
+{ status: "cancelled", requestId: string }
+{ status: "error",     requestId: string, error: string }
+```
+
+The promise **never rejects** on a normal `cancelled` / `error` outcome — those are part of the resolved value. It only rejects (throwing `AppPaymentsError`) on local failures: see the error table below.
+
+### The empty-`txHash` gotcha
+
+When the user **already owns** the item, the host short-circuits and returns
+`{ status: "success", txHash: "" }`. If you key off `if (result.txHash)` you'll
+mishandle the already-owned case. **Branch on `result.status`, never on `txHash`
+truthiness.**
+
+## Reading entitlements
+
+```ts
+if (await hasItem(7)) unlockPermanentSkin();
+const owned = await getOwnedItems(); // e.g. [1, 4, 7]
+```
+
+Both take an optional `{ timeoutMs?, window? }` (default timeout **10 s**) and follow the same error model as below.
+
+> **Host support:** `hasItem` / `getOwnedItems` require the appstore's offchain
+> entitlement handlers ([appstore PR #472](https://github.com/Elata-Biosciences/elata-appstore/pull/472)).
+> Until that ships, calls against the live host **time out**. Degrade gracefully:
+> use a short `timeoutMs` and, on timeout, fall back to showing items as
+> available rather than dead-ending the UI.
+
+```ts
+let ownedSet;
+try {
+  ownedSet = new Set(await getOwnedItems({ timeoutMs: 4000 }));
+} catch (err) {
+  if (err instanceof AppPaymentsError && err.code === "timeout") {
+    ownedSet = new Set();        // ownership unknown — show everything as buyable
+  } else throw err;
 }
 ```
 
-The promise never rejects on a normal `cancelled` / `error` outcome — those are part of the resolved value. It only rejects on:
+## The catalog and price units
 
-| Code            | Meaning                                                       |
-|-----------------|---------------------------------------------------------------|
-| `invalid_input` | `contentId` was not a non-negative integer (or similar)       |
-| `no_window`     | not running in a browser environment                          |
-| `no_parent`     | not running inside an iframe                                  |
-| `no_crypto`     | `crypto.randomUUID` is unavailable                            |
-| `timeout`       | no response within `timeoutMs` (default 5 minutes)            |
+`getCatalog()` returns the app's active listings so you don't hard-code IDs or prices:
 
-All errors are instances of `AppPaymentsError` with a `.code` field.
+```ts
+interface CatalogItem {
+  contentId: number;
+  title: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  priceUsdc: string; // USDC in BASE UNITS (6 decimals): "50000" === $0.05
+}
+```
+
+**Mind the two price conventions** — they share a field name but differ:
+
+- `CatalogItem.priceUsdc` is **base units** (6 decimals). Format it for display:
+  ```ts
+  const formatUsdc = (base: string) => `$${(Number(base) / 1e6).toFixed(2)}`;
+  formatUsdc("50000"); // "$0.05"
+  ```
+- `RequestPurchaseInput.priceUsdc` is a **free-form display hint** the SDK does
+  not interpret and the host overrides. Pass whatever you'd show the user
+  (e.g. the formatted string above).
+
+## Error model
+
+`requestPurchase` rejects, and the entitlement queries reject, only with `AppPaymentsError` (has a `.code`):
+
+| Code | Meaning |
+|------|---------|
+| `invalid_input` | `contentId` was not a non-negative integer (or a bad option type) |
+| `no_window` | not running in a browser environment |
+| `no_parent` | not running inside an iframe with an appstore parent |
+| `no_crypto` | `crypto.randomUUID` is unavailable |
+| `timeout` | no response within `timeoutMs` |
+| `not_authenticated` | host reports no signed-in user (entitlement queries) |
+| `fetch_failed` | host failed to look up entitlements |
 
 ## How it works
 
 1. Generates a `requestId` via `crypto.randomUUID()`.
 2. Posts `{ type: "elata:iap:request", requestId, contentId, ... }` to `window.parent`.
-3. Listens for `{ type: "elata:iap:result", requestId, status, ... }` from the parent.
+3. Listens for the matching `{ type: "elata:iap:result", requestId, ... }` reply.
 4. Resolves the promise; cleans up the listener and timer.
 
-The parent validates the message source against the app's registered origin before opening the payment modal, refetches the authoritative price from its API (the `priceUsdc` you send is display-only), runs the on-chain settlement, and replies back to the iframe.
+The entitlement queries work the same way with their own message types (`elata:iap:hasItem`, `elata:iap:listOwned`, `elata:iap:getCatalog`). The parent validates the message source against the app's registered origin before responding, refetches authoritative data, and replies.
 
 ## Security model
 
-- The app cannot fabricate ownership. Entitlements are written server-side after the on-chain transaction confirms.
-- The app cannot read card details, wallet keys, or session tokens. The parent owns those surfaces.
-- The price the app sends is a hint. The host always refetches.
-- Each `requestId` is unique; the host's purchase API has `(userId, requestId)` uniqueness so a replayed request returns the existing ownership without charging again.
+- The app **cannot fabricate ownership**. Entitlements are written server-side only after the on-chain transaction confirms; the app just reads them.
+- The app **cannot read** card details, wallet keys, or session tokens. The parent owns those surfaces.
+- The price the app sends is a **hint**; the host always refetches the authoritative price.
+- **Replay safety is per-request, not single-ownership enforcement.** The host keys on `(userId, requestId)`, so re-sending the *same* request is idempotent and won't double-charge. A *fresh* `requestId` for an item the user already owns records another entitlement row — the checkout UI is what discourages repeat buys, the server does not forbid them. Treat the host (via `getOwnedItems` / `hasItem`) as the source of truth for what a user owns.
+
+## Try it
+
+- **Runnable demo:** [`examples/iap-demo`](https://github.com/Elata-Biosciences/elata-bio-sdk/tree/main/examples/iap-demo) — one self-contained `index.html` that runs standalone via a built-in mock host, exercising the full flow.
+- **Guide:** [Using IAP in a browser app](https://github.com/Elata-Biosciences/elata-bio-sdk/blob/main/docs/guides/using-iap-in-a-browser-app.md).
+- **Platform integration guide:** `IAP_SDK_INTEGRATION.md` in the appstore repo (host-side details, product model, known gaps).
 
 ## Versioning
 

--- a/packages/app-payments/package.json
+++ b/packages/app-payments/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elata-biosciences/app-payments",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "In-app purchases for sandboxed apps in the Elata appstore",
 	"license": "MIT",
 	"author": "Elata",


### PR DESCRIPTION
Release-prep for an `app-payments` publish that includes `getCatalog`. Acts on doc-drift feedback: the front-door docs lagged the real exported API and the new demo.

## Why
- The npm README documented **only `requestPurchase`** — `hasItem`, `getOwnedItems`, and `getCatalog` (all exported in `src/client.ts`) were invisible, along with the entire ownership-gating pattern.
- IAP was missing from the guide set, `example-apps.md` cross-links, and the root README.
- The README's "Security model" bullet implied enforced buy-once, contradicting the appstore `IAP_SDK_INTEGRATION.md` (server accumulates rows; only `(userId, requestId)` is idempotent).
- npm `0.2.0` predates `getCatalog` and can't be overwritten, so a version bump is required before publishing the feature.

## Changes
- **`packages/app-payments/README.md`** — full four-function surface; correct-flow block (catalog → gate on ownership → purchase → apply → persist); empty-`txHash` gotcha; the two `priceUsdc` conventions + a base-units→display formatter; host-support note for `#472` with a graceful-degradation snippet; error-code table; corrected security bullet.
- **`docs/guides/using-iap-in-a-browser-app.md`** (new) — mirrors the `using-rppg`/`using-eeg` guide shape. Linked from the guides index and `example-apps.md`.
- **Root `README.md`** — adds `app-payments` to the capability table and package list (it was absent entirely).
- **`package.json`** — `0.2.0` → `0.3.0`.

## Not in this PR (publish last, by design)
- The actual `npm publish` (needs 2FA — your call).
- Bumping the demo's esm.sh pin to `0.3.0` (one-liner, after publish; the demo feature-detects `getCatalog` so it works in the meantime).
- The appstore `IAP_SDK_INTEGRATION.md` §7 edit (different repo).

## Verified
- [x] `pnpm run build` clean; `pnpm test` green (27/27).
- [x] New/updated relative doc links resolve.
- [ ] Skim the rendered README/guide before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)