### PR TITLE
docs: troubleshoot SPA history-router 404s on the appstore

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -26,6 +26,23 @@ assets from a path the browser can reach.
 
 If you are unsure, compare your app with the scaffolded `rppg-demo` app.
 
+## My app shows its own 404 page when played on app.elata.bio
+
+The appstore serves your app inside a sandboxed iframe under a subpath
+(`/app/<your-slug>/play/raw`), not at the domain root. If your app uses a
+history-based router (for example React Router's `BrowserRouter`, the default
+in Lovable exports), route matching depends on `location.pathname`, so the
+served subpath can land on your router's catch-all 404 page.
+
+The platform rewrites the iframe history to `/` before your scripts run, so
+recent appstore versions mask this. Still, do not depend on `location.pathname`:
+
+- prefer a hash-based router (React Router `HashRouter`, or equivalent), or
+- make your root route a splat (`path="*"`) instead of an exact `/`
+
+Asset URLs are unaffected either way — the appstore injects a `<base href>`
+that resolves relative asset paths through its proxy.
+
 ## I am not sure which package I need
 
 Start with [choose-the-right-package.md](choose-the-right-package.md).


### PR DESCRIPTION
Adds a troubleshooting entry for apps that show their own 404 page when played on app.elata.bio.

Cause: the appstore serves apps in a sandboxed iframe under `/app/<slug>/play/raw`, so history-based routers (React Router `BrowserRouter`, the Lovable default) match the subpath against their route table and land on the catch-all 404. Seen live with NeuroPulse.

The platform-side fix (Elata-Biosciences/elata-appstore#507) rewrites the iframe history to `/` before app scripts run, but app developers should still avoid depending on `location.pathname` — this entry recommends `HashRouter` or a splat root route.

Follow-up: mirror this entry in `elata-docs` (`sdk/operations/troubleshooting.mdx` in Elata-Biosciences/docs) per the docs-parity convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)