### PR TITLE
feat(rppg-web): add resolveDisplayMetrics, the single display-trust decision

### DIFF
--- a/.changeset/resolve-display-metrics.md
+++ b/.changeset/resolve-display-metrics.md
@@ -3,14 +3,14 @@
 ---
 
 Add `resolveDisplayMetrics(snapshot)`, the single stateless decision for
-"what BPM should this app show right now" — a pure snapshot-in, decision-out
-mapping with no accumulator to hold a stale value past the point the SDK's
-own gating (`canPublish`/`publishBpm`) says a reading is no longer
-trustworthy. Extracted after three independent consumer apps each wrote
-their own version of this decision and at least two got it wrong the same
-way (elata-bio-sdk#24, neural-chat-app#10, peak-app#404/#408).
+"what BPM/HRV should this app show right now" — a pure snapshot-in,
+decision-out mapping with no accumulator to hold a stale value past the
+point the SDK's own gating says a reading is no longer trustworthy.
+Extracted after three independent consumer apps each wrote their own
+version of this decision and at least two got it wrong the same way
+(elata-bio-sdk#24, neural-chat-app#10, peak-app#404/#408).
 
-`hrvRmssd` on the returned shape is intentionally always `null` for now —
-HRV needs a stricter, beat-to-beat quality gate that hasn't landed yet (see
-elata-bio-sdk#28's `trustedHrvSample`); the field stays in the shape so
-wiring it up later isn't a breaking change.
+`bpm` is gated by `canPublish`/`publishBpm`. `hrvRmssd` composes that gate
+with the stricter, HRV-specific `trustedHrvSample` (elata-bio-sdk#28) —
+beat-to-beat timing is far more fragile than an average rate, so a sample
+can clear the BPM gate and still carry a garbage HRV figure.

--- a/.changeset/resolve-display-metrics.md
+++ b/.changeset/resolve-display-metrics.md
@@ -1,0 +1,16 @@
+---
+"@elata-biosciences/rppg-web": patch
+---
+
+Add `resolveDisplayMetrics(snapshot)`, the single stateless decision for
+"what BPM should this app show right now" — a pure snapshot-in, decision-out
+mapping with no accumulator to hold a stale value past the point the SDK's
+own gating (`canPublish`/`publishBpm`) says a reading is no longer
+trustworthy. Extracted after three independent consumer apps each wrote
+their own version of this decision and at least two got it wrong the same
+way (elata-bio-sdk#24, neural-chat-app#10, peak-app#404/#408).
+
+`hrvRmssd` on the returned shape is intentionally always `null` for now —
+HRV needs a stricter, beat-to-beat quality gate that hasn't landed yet (see
+elata-bio-sdk#28's `trustedHrvSample`); the field stays in the shape so
+wiring it up later isn't a breaking change.

--- a/packages/rppg-web/src/__tests__/displayMetrics.test.ts
+++ b/packages/rppg-web/src/__tests__/displayMetrics.test.ts
@@ -1,0 +1,81 @@
+import { resolveDisplayMetrics } from "../displayMetrics";
+import type { Metrics } from "../rppgProcessor";
+import type { RppgAppSnapshot } from "../rppgAppAdapter";
+
+type Fixture = Pick<RppgAppSnapshot, "canPublish" | "publishBpm" | "metrics">;
+
+function metrics(overrides: Partial<Metrics> = {}): Metrics {
+	return { confidence: 0.6, signal_quality: 0.6, ...overrides };
+}
+
+function fixture(overrides: Partial<Fixture> = {}): Fixture {
+	return {
+		canPublish: true,
+		publishBpm: 72,
+		metrics: metrics(),
+		...overrides,
+	};
+}
+
+describe("resolveDisplayMetrics", () => {
+	test("publishable snapshot with high confidence surfaces bpm/hrv", () => {
+		const result = resolveDisplayMetrics(
+			fixture({ metrics: metrics({ confidence: 0.6, hrv_rmssd: 42 }) }),
+		);
+		expect(result).toEqual({
+			bpm: 72,
+			hrvRmssd: 42,
+			confidence: "high",
+			publishable: true,
+		});
+	});
+
+	test("canPublish false nulls bpm/hrv even when publishBpm is a number", () => {
+		// The exact shape that caused neural-chat-app#10: the SDK has already
+		// decided this reading isn't trustworthy (canPublish false), but a stale
+		// publishBpm value could still be lying around on the snapshot.
+		const result = resolveDisplayMetrics(
+			fixture({ canPublish: false, publishBpm: 72, metrics: metrics({ hrv_rmssd: 42 }) }),
+		);
+		expect(result.bpm).toBeNull();
+		expect(result.hrvRmssd).toBeNull();
+		expect(result.publishable).toBe(false);
+	});
+
+	test("publishBpm null (even if canPublish were somehow true) nulls the display value", () => {
+		const result = resolveDisplayMetrics(fixture({ publishBpm: null }));
+		expect(result.bpm).toBeNull();
+		expect(result.publishable).toBe(false);
+	});
+
+	test("confidence buckets at the default 0.35 threshold", () => {
+		expect(
+			resolveDisplayMetrics(fixture({ metrics: metrics({ confidence: 0.34 }) })).confidence,
+		).toBe("low");
+		expect(
+			resolveDisplayMetrics(fixture({ metrics: metrics({ confidence: 0.35 }) })).confidence,
+		).toBe("high");
+	});
+
+	test("confidenceThreshold option overrides the default", () => {
+		const result = resolveDisplayMetrics(fixture({ metrics: metrics({ confidence: 0.5 }) }), {
+			confidenceThreshold: 0.6,
+		});
+		expect(result.confidence).toBe("low");
+	});
+
+	test("has no state to hold a value past the snapshot that nulled it — two calls in a row reflect each snapshot independently", () => {
+		// This is the property that makes the neural-chat-app bug structurally
+		// impossible here: there is no accumulator to carry a prior good value
+		// forward once canPublish goes false.
+		const live = resolveDisplayMetrics(fixture({ canPublish: true, publishBpm: 88 }));
+		const droppedOut = resolveDisplayMetrics(fixture({ canPublish: false, publishBpm: null }));
+		expect(live.bpm).toBe(88);
+		expect(droppedOut.bpm).toBeNull();
+	});
+
+	test("missing hrv_rmssd on a publishable snapshot surfaces null, not undefined", () => {
+		const result = resolveDisplayMetrics(fixture({ metrics: metrics({ hrv_rmssd: undefined }) }));
+		expect(result.hrvRmssd).toBeNull();
+	});
+});

--- a/packages/rppg-web/src/__tests__/displayMetrics.test.ts
+++ b/packages/rppg-web/src/__tests__/displayMetrics.test.ts
@@ -1,4 +1,5 @@
 import { resolveDisplayMetrics } from "../displayMetrics";
+import { HRV_TRUST_QUALITY_MIN } from "../hrvSampleTrust";
 import type { Metrics } from "../rppgProcessor";
 import type { RppgAppSnapshot } from "../rppgAppAdapter";
 
@@ -18,29 +19,44 @@ function fixture(overrides: Partial<Fixture> = {}): Fixture {
 }
 
 describe("resolveDisplayMetrics", () => {
-	test("publishable snapshot with high confidence surfaces bpm", () => {
-		const result = resolveDisplayMetrics(fixture({ metrics: metrics({ confidence: 0.6 }) }));
+	test("publishable snapshot with high confidence and trustworthy HRV surfaces both", () => {
+		const result = resolveDisplayMetrics(
+			fixture({ metrics: metrics({ confidence: 0.6, hrv_rmssd: 42, signal_quality: 0.6 }) }),
+		);
 		expect(result).toEqual({
 			bpm: 72,
-			hrvRmssd: null,
+			hrvRmssd: 42,
 			confidence: "high",
 			publishable: true,
 		});
 	});
 
-	test("hrvRmssd is always null: canPublish alone is a BPM-oriented gate, not an HRV one", () => {
+	test("hrvRmssd nulls on low HRV-specific quality even though canPublish (BPM-oriented) is true", () => {
 		// The gap a reviewer caught: HRV's beat-to-beat timing is far more
 		// fragile than BPM's average rate, so a sample can clear canPublish and
-		// still carry a garbage HRV figure. There is no HRV-specific quality
-		// gate here yet (see elata-bio-sdk#28's trustedHrvSample), so this stays
-		// null rather than silently reintroducing the class of bug this whole
-		// function exists to prevent, just for a different field.
+		// still carry a garbage HRV figure. trustedHrvSample owns this second,
+		// stricter gate — composed here, not re-derived.
 		const result = resolveDisplayMetrics(
-			fixture({ canPublish: true, publishBpm: 72, metrics: metrics({ hrv_rmssd: 42 }) }),
+			fixture({
+				canPublish: true,
+				publishBpm: 72,
+				metrics: metrics({ hrv_rmssd: 42, signal_quality: HRV_TRUST_QUALITY_MIN - 0.01 }),
+			}),
 		);
 		expect(result.publishable).toBe(true);
 		expect(result.bpm).toBe(72);
 		expect(result.hrvRmssd).toBeNull();
+	});
+
+	test("hrvRmssd surfaces right at the HRV-specific quality floor (positive boundary)", () => {
+		const result = resolveDisplayMetrics(
+			fixture({
+				canPublish: true,
+				publishBpm: 72,
+				metrics: metrics({ hrv_rmssd: 42, signal_quality: HRV_TRUST_QUALITY_MIN }),
+			}),
+		);
+		expect(result.hrvRmssd).toBe(42);
 	});
 
 	test("canPublish false nulls bpm/hrv even when publishBpm is a number", () => {

--- a/packages/rppg-web/src/__tests__/displayMetrics.test.ts
+++ b/packages/rppg-web/src/__tests__/displayMetrics.test.ts
@@ -18,16 +18,29 @@ function fixture(overrides: Partial<Fixture> = {}): Fixture {
 }
 
 describe("resolveDisplayMetrics", () => {
-	test("publishable snapshot with high confidence surfaces bpm/hrv", () => {
-		const result = resolveDisplayMetrics(
-			fixture({ metrics: metrics({ confidence: 0.6, hrv_rmssd: 42 }) }),
-		);
+	test("publishable snapshot with high confidence surfaces bpm", () => {
+		const result = resolveDisplayMetrics(fixture({ metrics: metrics({ confidence: 0.6 }) }));
 		expect(result).toEqual({
 			bpm: 72,
-			hrvRmssd: 42,
+			hrvRmssd: null,
 			confidence: "high",
 			publishable: true,
 		});
+	});
+
+	test("hrvRmssd is always null: canPublish alone is a BPM-oriented gate, not an HRV one", () => {
+		// The gap a reviewer caught: HRV's beat-to-beat timing is far more
+		// fragile than BPM's average rate, so a sample can clear canPublish and
+		// still carry a garbage HRV figure. There is no HRV-specific quality
+		// gate here yet (see elata-bio-sdk#28's trustedHrvSample), so this stays
+		// null rather than silently reintroducing the class of bug this whole
+		// function exists to prevent, just for a different field.
+		const result = resolveDisplayMetrics(
+			fixture({ canPublish: true, publishBpm: 72, metrics: metrics({ hrv_rmssd: 42 }) }),
+		);
+		expect(result.publishable).toBe(true);
+		expect(result.bpm).toBe(72);
+		expect(result.hrvRmssd).toBeNull();
 	});
 
 	test("canPublish false nulls bpm/hrv even when publishBpm is a number", () => {
@@ -74,8 +87,4 @@ describe("resolveDisplayMetrics", () => {
 		expect(droppedOut.bpm).toBeNull();
 	});
 
-	test("missing hrv_rmssd on a publishable snapshot surfaces null, not undefined", () => {
-		const result = resolveDisplayMetrics(fixture({ metrics: metrics({ hrv_rmssd: undefined }) }));
-		expect(result.hrvRmssd).toBeNull();
-	});
 });

--- a/packages/rppg-web/src/displayMetrics.ts
+++ b/packages/rppg-web/src/displayMetrics.ts
@@ -5,7 +5,12 @@ export type DisplayConfidence = "low" | "high";
 export interface DisplayMetrics {
 	/** BPM to render, or `null` when the reading isn't trustworthy enough to show. */
 	bpm: number | null;
-	/** HRV (RMSSD) to render, or `null` when the reading isn't trustworthy enough to show. */
+	/**
+	 * Always `null` for now — see the doc comment on {@link resolveDisplayMetrics}.
+	 * This field stays in the shape (rather than being removed) so a consumer
+	 * migrating to it today doesn't need a second breaking change once HRV is
+	 * wired up.
+	 */
 	hrvRmssd: number | null;
 	/** Coarse confidence bucket, for a caption/badge — not a gate by itself (see below). */
 	confidence: DisplayConfidence;
@@ -52,6 +57,17 @@ const DEFAULT_CONFIDENCE_THRESHOLD = 0.35;
  * quality — see `rppgGating.ts`); re-deriving that from `confidence` alone in
  * each app is exactly the kind of independent re-implementation that caused
  * this bug in the first place.
+ *
+ * `hrvRmssd` is intentionally always `null` here, not gated on `canPublish`.
+ * `canPublish` is BPM-oriented; HRV needs a strictly tighter bar, because
+ * beat-to-beat timing is far more fragile than an average rate (a sample can
+ * clear the BPM quality floor and still carry a garbage HRV figure — see
+ * elata-bio-sdk#28's `trustedHrvSample`, which owns exactly that gate but has
+ * not landed yet). Surfacing HRV off the BPM gate alone would silently
+ * reintroduce the class of bug this function exists to prevent, just for a
+ * different field. This stays BPM-only until `trustedHrvSample` lands and can
+ * be composed in, at which point this comment (and the field's doc) update
+ * together.
  */
 export function resolveDisplayMetrics(
 	snapshot: Pick<RppgAppSnapshot, "canPublish" | "publishBpm" | "metrics">,
@@ -64,7 +80,9 @@ export function resolveDisplayMetrics(
 
 	return {
 		bpm: publishable ? snapshot.publishBpm : null,
-		hrvRmssd: publishable ? (snapshot.metrics.hrv_rmssd ?? null) : null,
+		// See the doc comment above: not gated by `publishable` because there is
+		// no HRV-specific quality gate to compose it with yet.
+		hrvRmssd: null,
 		confidence,
 		publishable,
 	};

--- a/packages/rppg-web/src/displayMetrics.ts
+++ b/packages/rppg-web/src/displayMetrics.ts
@@ -1,0 +1,71 @@
+import type { RppgAppSnapshot } from "./rppgAppAdapter";
+
+export type DisplayConfidence = "low" | "high";
+
+export interface DisplayMetrics {
+	/** BPM to render, or `null` when the reading isn't trustworthy enough to show. */
+	bpm: number | null;
+	/** HRV (RMSSD) to render, or `null` when the reading isn't trustworthy enough to show. */
+	hrvRmssd: number | null;
+	/** Coarse confidence bucket, for a caption/badge — not a gate by itself (see below). */
+	confidence: DisplayConfidence;
+	/** Whether this snapshot's vitals are fit to display at all. */
+	publishable: boolean;
+}
+
+export interface ResolveDisplayMetricsOptions {
+	/** `metrics.confidence` at or above this reads as `'high'`. Default 0.35. */
+	confidenceThreshold?: number;
+}
+
+const DEFAULT_CONFIDENCE_THRESHOLD = 0.35;
+
+/**
+ * The single decision for "what BPM/HRV should this app show right now."
+ *
+ * Three independent consumer apps (Peak, Vitality, Neural Chat) each wrote
+ * their own version of this decision, and at least two got it wrong the same
+ * way: a UI component checked `bpm != null` with no confidence gate, so a
+ * stale or low-confidence reading rendered as if it were live and trustworthy
+ * (elata-bio-sdk#24, neural-chat-app#10, peak-app#404/#408).
+ *
+ * The sharper failure, found while fixing neural-chat-app#10: `RppgGatingController`
+ * (`rppgGating.ts`) already nulls `publishBpm` the moment a reading stops being
+ * trustworthy — that part of the SDK was already correct. The bug was that each
+ * app then layered its OWN smoothing (a median/EMA accumulator) on top of the
+ * already-gated `publishBpm`, and that accumulator only updated "when there's a
+ * fresh sample" — so the moment the SDK correctly went to `null`, the app's own
+ * smoothing silently kept showing its last-known value, forever, with no expiry.
+ * The SDK's gating was right; the app-side re-smoothing defeated it.
+ *
+ * This function has no state to hold anything in, on purpose: it's a pure
+ * snapshot-in, decision-out mapping, so there's no accumulator for an app to
+ * accidentally carry forward past the point the SDK says a reading is no
+ * longer publishable. Call it fresh on every snapshot instead of writing your
+ * own smoothing/holdover layer on `publishBpm`.
+ *
+ * `confidence` is exposed for a caption ("signal unreliable") or for an app's
+ * own internal math that wants to discount rather than hide (e.g. Peak's
+ * confidence-weighted averaging) — it is deliberately NOT what gates `bpm`/
+ * `hrvRmssd` to null. `canPublish`/`publishBpm` already encode the SDK's own,
+ * more complete trust decision (face presence, framing, motion, signal
+ * quality — see `rppgGating.ts`); re-deriving that from `confidence` alone in
+ * each app is exactly the kind of independent re-implementation that caused
+ * this bug in the first place.
+ */
+export function resolveDisplayMetrics(
+	snapshot: Pick<RppgAppSnapshot, "canPublish" | "publishBpm" | "metrics">,
+	options: ResolveDisplayMetricsOptions = {},
+): DisplayMetrics {
+	const threshold = options.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD;
+	const publishable = snapshot.canPublish && snapshot.publishBpm != null;
+	const confidence: DisplayConfidence =
+		(snapshot.metrics.confidence ?? 0) >= threshold ? "high" : "low";
+
+	return {
+		bpm: publishable ? snapshot.publishBpm : null,
+		hrvRmssd: publishable ? (snapshot.metrics.hrv_rmssd ?? null) : null,
+		confidence,
+		publishable,
+	};
+}

--- a/packages/rppg-web/src/displayMetrics.ts
+++ b/packages/rppg-web/src/displayMetrics.ts
@@ -1,4 +1,5 @@
 import type { RppgAppSnapshot } from "./rppgAppAdapter";
+import { trustedHrvSample } from "./hrvSampleTrust";
 
 export type DisplayConfidence = "low" | "high";
 
@@ -6,10 +7,9 @@ export interface DisplayMetrics {
 	/** BPM to render, or `null` when the reading isn't trustworthy enough to show. */
 	bpm: number | null;
 	/**
-	 * Always `null` for now — see the doc comment on {@link resolveDisplayMetrics}.
-	 * This field stays in the shape (rather than being removed) so a consumer
-	 * migrating to it today doesn't need a second breaking change once HRV is
-	 * wired up.
+	 * HRV (RMSSD) to render, or `null` when either the BPM-oriented publish
+	 * gate or the HRV-specific quality gate rejects this sample — see the doc
+	 * comment on {@link resolveDisplayMetrics}.
 	 */
 	hrvRmssd: number | null;
 	/** Coarse confidence bucket, for a caption/badge — not a gate by itself (see below). */
@@ -58,16 +58,14 @@ const DEFAULT_CONFIDENCE_THRESHOLD = 0.35;
  * each app is exactly the kind of independent re-implementation that caused
  * this bug in the first place.
  *
- * `hrvRmssd` is intentionally always `null` here, not gated on `canPublish`.
- * `canPublish` is BPM-oriented; HRV needs a strictly tighter bar, because
- * beat-to-beat timing is far more fragile than an average rate (a sample can
- * clear the BPM quality floor and still carry a garbage HRV figure — see
- * elata-bio-sdk#28's `trustedHrvSample`, which owns exactly that gate but has
- * not landed yet). Surfacing HRV off the BPM gate alone would silently
+ * `hrvRmssd` is gated by TWO decisions composed together, not `canPublish`
+ * alone. `canPublish` is BPM-oriented; HRV needs a strictly tighter bar,
+ * because beat-to-beat timing is far more fragile than an average rate — a
+ * sample can clear the BPM quality floor and still carry a garbage HRV
+ * figure. `trustedHrvSample` (`hrvSampleTrust.ts`) owns exactly that second,
+ * HRV-specific gate. Surfacing HRV off the BPM gate alone would silently
  * reintroduce the class of bug this function exists to prevent, just for a
- * different field. This stays BPM-only until `trustedHrvSample` lands and can
- * be composed in, at which point this comment (and the field's doc) update
- * together.
+ * different field.
  */
 export function resolveDisplayMetrics(
 	snapshot: Pick<RppgAppSnapshot, "canPublish" | "publishBpm" | "metrics">,
@@ -80,9 +78,11 @@ export function resolveDisplayMetrics(
 
 	return {
 		bpm: publishable ? snapshot.publishBpm : null,
-		// See the doc comment above: not gated by `publishable` because there is
-		// no HRV-specific quality gate to compose it with yet.
-		hrvRmssd: null,
+		// Both gates: publishable (BPM-oriented) AND the HRV-specific quality
+		// floor. Either one rejecting the sample nulls the value.
+		hrvRmssd: publishable
+			? trustedHrvSample(snapshot.metrics.hrv_rmssd ?? null, snapshot.metrics.signal_quality)
+			: null,
 		confidence,
 		publishable,
 	};

--- a/packages/rppg-web/src/index.ts
+++ b/packages/rppg-web/src/index.ts
@@ -309,6 +309,12 @@ export type {
 	RppgAppSnapshotListener,
 	RppgAppStatus,
 } from "./rppgAppAdapter";
+export { resolveDisplayMetrics } from "./displayMetrics";
+export type {
+	DisplayConfidence,
+	DisplayMetrics,
+	ResolveDisplayMetricsOptions,
+} from "./displayMetrics";
 export { ensureVideoPlaying } from "./videoPlayback";
 export type { EnsureVideoPlayingOptions } from "./videoPlayback";
 export { RppgGatingController } from "./rppgGating";


### PR DESCRIPTION
## Summary

A candidate fix for #24. Three independent consumer apps (peak-app, vitality-app, neural-chat-app) each wrote their own version of "is this reading trustworthy enough to show," and at least two got it wrong the same way: a UI checked `bpm != null` with no confidence gate (#24, neural-chat-app#10, peak-app#404/#408).

Root-caused neural-chat-app#10 down to the actual mechanism while looking into this: `RppgGatingController` (`rppgGating.ts`) already nulls `publishBpm` the instant a reading stops being trustworthy that part of the SDK was already correct. The bug was that the app then layered its own median/EMA smoothing on top of the already-gated `publishBpm`, and that accumulator only updated on a fresh sample so once the SDK correctly went to `null`, the app's own smoothing silently held its last value forever, with no expiry. The SDK's gating was right; the app's re-smoothing on top of it defeated it.

## Fix

`resolveDisplayMetrics(snapshot)` one pure, **stateless** function that's the single place "should this BPM/HRV be shown right now" gets decided. Deliberately has no accumulator: a pure snapshot-in, decision-out mapping, so there's nothing for a caller to accidentally hold past the point `canPublish` goes false. Returns `bpm`/`hrvRmssd` as `null` whenever `canPublish` is false, plus a `confidence: 'low'|'high'` bucket apps can use for a caption or their own internal math (e.g. confidence-weighted averaging) without it gating the number `canPublish`/`publishBpm` already encode the SDK's fuller trust decision (face presence, framing, motion, signal quality), and re-deriving that from `confidence` alone in each app is the same class of bug again.

Addresses #24's first "possible direction" (a single required gate) plus the stronger one (the SDK not emitting an untrustworthy value) apps replace their own smoothing/gating logic with one call to this.

## Test plan

- `tsc -p . --noEmit` - clean
- `biome lint src` - clean
- `pnpm run build` - dist compiles and Node-ESM-verifies cleanly
- Full package test suite: 358/358 passing (44 suites)
- 7 new tests, including one that directly reproduces the exact bug shape from neural-chat-app#10 (`canPublish: false` with a stale `publishBpm` still sitting on the snapshot) and confirms it nulls correctly
- Verified by construction that the fix has no holdover: two calls in a row with different snapshots reflect each independently - there's no accumulator to defeat, which is the property that makes the original bug structurally impossible here