### PR TITLE
feat(rppg-web): add the reliability-gating surface

### DIFF
--- a/.changeset/gate-reliability-into-rppg-web.md
+++ b/.changeset/gate-reliability-into-rppg-web.md
@@ -1,0 +1,13 @@
+---
+"@elata-biosciences/rppg-web": minor
+---
+
+Add the reliability-gating surface: `trustedHrvSample`, `calibrationStage`,
+camera-frozen-frame detection (`initialLiveness`/`observeFrame`/etc.),
+`landmarkMotion`, and `fitExposureResponse`. Extracted from three independent
+consumer apps (peak-app, vitality-app, neural-chat-app) that had each been
+hand-copying and re-drifting this exact logic — see elata-bio-sdk#24/#26/#405.
+
+Deliberately excludes display copy and CSS tone classes (`CALIBRATION_LABEL`,
+`calibrationLabelTone`, `signalTier`'s tone field): each app's own framing
+(work vs. recovery vs. chat) genuinely differs and stays app-owned.

--- a/packages/rppg-web/src/__tests__/calibration.test.ts
+++ b/packages/rppg-web/src/__tests__/calibration.test.ts
@@ -1,0 +1,153 @@
+import { calibrationStage } from "../calibration";
+
+describe("calibrationStage", () => {
+	const base = {
+		paused: false,
+		locked: false,
+		conditionsGood: true,
+		trustworthy: false,
+		progressPct: 0,
+	};
+
+	test('is "positioning" when conditions are not good — no progress on bad data', () => {
+		expect(calibrationStage({ ...base, conditionsGood: false })).toBe("positioning");
+		// Bad conditions win even after progress accrues or the read looks trusted
+		// (e.g. drifting out of frame mid-scan).
+		expect(calibrationStage({ ...base, conditionsGood: false, progressPct: 40 })).toBe(
+			"positioning",
+		);
+		expect(calibrationStage({ ...base, conditionsGood: false, trustworthy: true })).toBe(
+			"positioning",
+		);
+	});
+
+	test('is "acquiring" on a good signal before any progress (warm-up)', () => {
+		expect(calibrationStage({ ...base, progressPct: 0 })).toBe("acquiring");
+	});
+
+	describe("the calibrator restarting", () => {
+		// The SDK empties its own buffer after ten rejects in a row before sample 18.
+		// The ring cannot retreat (its high-water mark is right about that), so
+		// without a stage of its own the only thing the reader gets is a bar that has
+		// stopped dead for five seconds or more. That silence is what was reported as
+		// lag.
+		test("says so while the count is building again", () => {
+			expect(calibrationStage({ ...base, progressPct: 60, restarted: true })).toBe(
+				"restarting",
+			);
+		});
+
+		test("never displaces advice the reader can act on", () => {
+			// "Hold still, more light" is actionable. "Starting again" is not, so it
+			// must never take the place of the first.
+			expect(
+				calibrationStage({ ...base, conditionsGood: false, restarted: true, progressPct: 60 }),
+			).toBe("positioning");
+			expect(calibrationStage({ ...base, paused: true, restarted: true })).toBe("paused");
+			expect(calibrationStage({ ...base, locked: true, restarted: true })).toBe("locked");
+			expect(calibrationStage({ ...base, armed: false, restarted: true })).toBe("ready");
+		});
+
+		test("gets out of the way once the reading is trustworthy again", () => {
+			expect(calibrationStage({ ...base, trustworthy: true, restarted: false })).toBe(
+				"measuring",
+			);
+		});
+	});
+
+	test('is "calibrating" while a clean read builds toward trust', () => {
+		expect(calibrationStage({ ...base, progressPct: 1 })).toBe("calibrating");
+		expect(calibrationStage({ ...base, progressPct: 80 })).toBe("calibrating");
+	});
+
+	test('is "measuring" once the framed read is trustworthy (capturing the reading)', () => {
+		expect(calibrationStage({ ...base, trustworthy: true, progressPct: 95 })).toBe("measuring");
+	});
+
+	test('reports "locked" when complete', () => {
+		expect(
+			calibrationStage({ ...base, locked: true, trustworthy: true, progressPct: 100 }),
+		).toBe("locked");
+	});
+
+	test("an explicit pause wins over every other stage", () => {
+		expect(calibrationStage({ ...base, paused: true, locked: true, progressPct: 100 })).toBe(
+			"paused",
+		);
+		expect(calibrationStage({ ...base, paused: true, conditionsGood: false })).toBe("paused");
+		expect(calibrationStage({ ...base, paused: true, trustworthy: true })).toBe("paused");
+	});
+
+	test("a lock wins over the in-progress capture", () => {
+		expect(calibrationStage({ ...base, locked: true, trustworthy: true, progressPct: 40 })).toBe(
+			"locked",
+		);
+	});
+
+	describe("adapting to light", () => {
+		/**
+		 * Reported 2026-08-02: numbers come back too high when calibrating in the
+		 * dark, and the reading starts before the light has adapted. This stage
+		 * exists so nothing is gathered — and nothing is BLAMED ON THE READER —
+		 * while the app's own fill-light and the camera's exposure are still
+		 * moving.
+		 */
+		test("wins over positioning: nothing to fix is not the same message as bad conditions", () => {
+			expect(calibrationStage({ ...base, conditionsGood: false, adaptingLight: true })).toBe(
+				"adapting-light",
+			);
+		});
+
+		test("wins over acquiring and calibrating too — any accrual during this window is what broke", () => {
+			expect(calibrationStage({ ...base, progressPct: 0, adaptingLight: true })).toBe(
+				"adapting-light",
+			);
+			expect(calibrationStage({ ...base, progressPct: 40, adaptingLight: true })).toBe(
+				"adapting-light",
+			);
+			expect(
+				calibrationStage({ ...base, trustworthy: true, progressPct: 95, adaptingLight: true }),
+			).toBe("adapting-light");
+		});
+
+		test("never displaces pause or lock — those are more true than \"still adjusting\"", () => {
+			expect(calibrationStage({ ...base, paused: true, adaptingLight: true })).toBe("paused");
+			expect(calibrationStage({ ...base, locked: true, adaptingLight: true })).toBe("locked");
+			expect(calibrationStage({ ...base, armed: false, adaptingLight: true })).toBe("ready");
+		});
+
+		test("the anti-vacuity partner: false/absent behaves exactly as before this field existed", () => {
+			expect(calibrationStage({ ...base, adaptingLight: false })).toBe("acquiring");
+			expect(calibrationStage({ ...base })).toBe("acquiring");
+		});
+	});
+});
+
+describe("held (unarmed) capture", () => {
+	test("reports the ready stage, whatever the signal is doing", () => {
+		// A ring that reads "getting a clear signal" while the capture is held IS
+		// calibration to the person watching, whatever the internals do.
+		expect(
+			calibrationStage({
+				paused: false,
+				locked: false,
+				conditionsGood: true,
+				trustworthy: true,
+				progressPct: 80,
+				armed: false,
+			}),
+		).toBe("ready");
+	});
+
+	test("armed defaulting to true preserves every existing stage decision", () => {
+		expect(
+			calibrationStage({
+				paused: false,
+				locked: false,
+				conditionsGood: true,
+				trustworthy: true,
+				progressPct: 80,
+			}),
+		).toBe("measuring");
+	});
+});

--- a/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
+++ b/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
@@ -3,6 +3,7 @@ import {
 	STARTUP_GRACE_MS,
 	initialLiveness,
 	observeFrame,
+	pastStartupGrace,
 	sameSignature,
 	signatureOf,
 } from "../cameraLiveness";
@@ -122,6 +123,23 @@ describe("a driver warming up is not accused", () => {
 		expect(state.frozen).toBe(false);
 		state = observeFrame(state, covered.slice(), STARTUP_GRACE_MS);
 		expect(state.frozen).toBe(true);
+	});
+});
+
+describe("pastStartupGrace", () => {
+	test("is false before STARTUP_GRACE_MS has elapsed, true at and past it", () => {
+		// Shared by observeFrame's own frozen check and by the zero-frames-ever
+		// case a consumer (e.g. peak-app's CameraPreview.tsx) has no signature
+		// to compare and so cannot call observeFrame at all — one threshold,
+		// two callers.
+		expect(pastStartupGrace(1000, 1000 + STARTUP_GRACE_MS - 1)).toBe(false);
+		expect(pastStartupGrace(1000, 1000 + STARTUP_GRACE_MS)).toBe(true);
+		expect(pastStartupGrace(1000, 1000 + STARTUP_GRACE_MS + 5000)).toBe(true);
+	});
+
+	test("measures from the given start, not from zero", () => {
+		expect(pastStartupGrace(50_000, 50_000 + STARTUP_GRACE_MS)).toBe(true);
+		expect(pastStartupGrace(50_000, 50_000 + STARTUP_GRACE_MS - 1)).toBe(false);
 	});
 });
 

--- a/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
+++ b/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
@@ -1,0 +1,176 @@
+import {
+	FROZEN_MS,
+	STARTUP_GRACE_MS,
+	initialLiveness,
+	observeFrame,
+	sameSignature,
+	signatureOf,
+} from "../cameraLiveness";
+
+/**
+ * A dark room and a dead camera are different things, and the whole point of
+ * this module is that it can tell them apart WITHOUT a camera or a dark room.
+ *
+ * Two anchors hold each other up here, and both are needed:
+ *
+ *  - "a still image is caught" alone passes if the rule degrades to `frozen:
+ *    true` always, which would put "no picture from your camera" over the
+ *    owner's working face. That is the exact bug this replaces.
+ *  - "a live camera is never accused" alone passes if the rule degrades to
+ *    `frozen: false` always, which is the silence he has been fighting for a
+ *    week.
+ */
+
+/** A frame of flat mid-grey: what a placeholder card's background looks like. */
+function flat(value = 40, pixels = 256): number[] {
+	return Array.from({ length: pixels * 3 }, () => value);
+}
+
+/** The same picture, with sensor noise on exactly one sample. */
+function noisier(sig: number[], at = 7, by = 1): number[] {
+	const out = sig.slice();
+	out[at] += by;
+	return out;
+}
+
+describe("signatureOf", () => {
+	test("keeps colour and drops alpha, which is 255 on every camera frame", () => {
+		expect(signatureOf([1, 2, 3, 255, 4, 5, 6, 255])).toEqual([1, 2, 3, 4, 5, 6]);
+	});
+
+	test("ignores a trailing partial pixel rather than reading undefined", () => {
+		expect(signatureOf([1, 2, 3, 255, 9, 9])).toEqual([1, 2, 3]);
+	});
+});
+
+describe("sameSignature", () => {
+	test("is exact: one count of difference in one sample is a difference", () => {
+		const a = flat();
+		expect(sameSignature(a, a.slice())).toBe(true);
+		expect(sameSignature(a, noisier(a))).toBe(false);
+	});
+
+	test("treats a different length as different rather than comparing the overlap", () => {
+		expect(sameSignature([1, 2, 3], [1, 2, 3, 4])).toBe(false);
+	});
+});
+
+describe("a substituted still image is caught", () => {
+	test("reports frozen once the identical picture has run for FROZEN_MS, past startup grace", () => {
+		// His machine hands the browser a "camera off" card: the same bitmap, over
+		// and over. Nothing about it is dark enough to catch with a brightness
+		// threshold, because the glyph on it is bright. It is caught by being STILL.
+		// Armed at t=14000 (an arbitrary time well after page load), so the
+		// startup grace measured from THIS session's first frame has already
+		// cleared by the time the freeze is asserted below — a mid-session
+		// freeze, not a driver warming up.
+		// Since the very first frame of THIS session never changes, `changedAt`
+		// stays pinned to `armedAt` too, so STARTUP_GRACE_MS (the larger of the
+		// two windows) is what actually gates the verdict here.
+		const card = flat();
+		const armedAt = 24_000; // arbitrary time well after page load
+		let state = initialLiveness(armedAt);
+		state = observeFrame(state, card, armedAt);
+		expect(state.frozen).toBe(false);
+
+		state = observeFrame(state, card.slice(), armedAt + STARTUP_GRACE_MS - 1);
+		expect(state.frozen).toBe(false);
+
+		state = observeFrame(state, card.slice(), armedAt + STARTUP_GRACE_MS);
+		expect(state.frozen).toBe(true);
+	});
+
+	test("never claims frozen off a single frame, however long the app has been open", () => {
+		// Before two pictures have been compared there is no evidence either way,
+		// and an accusation with no evidence is the failure mode being replaced.
+		const state = observeFrame(initialLiveness(0), flat(), 60_000);
+		expect(state.frozen).toBe(false);
+	});
+});
+
+describe("a driver warming up is not accused", () => {
+	test("reproduces the 2026-08-02 report: identical from the very first frame, in the dark, at start", () => {
+		/**
+		 * THE REGRESSION THIS EXISTS FOR. "keeps showing camera off icon through
+		 * calibration when it is dark initially." Some webcam drivers hand back a
+		 * duplicate of the first captured buffer for the first few frames while
+		 * the sensor's real (longer, dark-room) exposure is still being read out.
+		 * That duplicate is bit-identical, and FROZEN_MS alone caught it as a
+		 * covered camera. It always cleared once real frames started arriving,
+		 * which is the "initially" in his report.
+		 */
+		const startupDupe = flat(3); // a dark frame, repeated verbatim by the driver
+		let state = initialLiveness(0);
+		state = observeFrame(state, startupDupe, 0);
+		for (let t = 200; t < STARTUP_GRACE_MS; t += 200) {
+			state = observeFrame(state, startupDupe.slice(), t);
+			expect(state.frozen).toBe(false);
+		}
+	});
+
+	test("still catches a camera covered from the very first frame, just not instantly", () => {
+		// The anti-vacuity partner: the startup grace must not become a licence to
+		// never accuse a camera that is covered from t=0. Since the very first
+		// frame never changes, `changedAt` stays at 0 too, so STARTUP_GRACE_MS
+		// (4000ms) is the binding constraint here, not FROZEN_MS (2000ms) — by the
+		// time the grace window clears, the identical streak has already run
+		// longer than FROZEN_MS regardless.
+		const covered = flat(0);
+		let state = initialLiveness(0);
+		state = observeFrame(state, covered, 0);
+		state = observeFrame(state, covered.slice(), STARTUP_GRACE_MS - 1);
+		expect(state.frozen).toBe(false);
+		state = observeFrame(state, covered.slice(), STARTUP_GRACE_MS);
+		expect(state.frozen).toBe(true);
+	});
+});
+
+describe("a live camera is never accused", () => {
+	test("stays live on a pitch-dark frame that still carries sensor noise", () => {
+		/**
+		 * THE REGRESSION THIS EXISTS FOR. The owner's room is dark, so the previous
+		 * rule ("is the frame dark?") hid his face for a whole working reading and
+		 * left him asking whether the app was broken. Near-black is a legitimate
+		 * picture. Only stillness is not.
+		 */
+		let sig = flat(2);
+		let state = initialLiveness(0);
+		for (let t = 0; t <= FROZEN_MS * 5; t += 200) {
+			state = observeFrame(state, sig, t);
+			expect(state.frozen).toBe(false);
+			sig = noisier(sig, (t / 200) % sig.length, t % 2 ? 1 : -1);
+		}
+	});
+
+	test("stays live on a camera that has dropped to 2fps in the dark", () => {
+		/**
+		 * Low light collapses a webcam's frame rate, so the same picture is sampled
+		 * many times in a row while the camera is working perfectly. A rule counting
+		 * identical frames would accuse it; the clock does not, because a new
+		 * picture still lands well inside the window.
+		 */
+		let sig = flat(3);
+		let state = initialLiveness(0);
+		for (let frame = 0; frame < 10; frame++) {
+			const arrivesAt = frame * 500; // 2fps
+			for (let t = arrivesAt; t < arrivesAt + 500; t += 100) {
+				state = observeFrame(state, sig, t);
+				expect(state.frozen).toBe(false);
+			}
+			sig = noisier(sig, frame, 1);
+		}
+	});
+
+	test("clears a frozen verdict the moment the picture moves again", () => {
+		// He flips the camera switch back on. The accusation must not latch: a
+		// status that can only go one way is a status that stops meaning anything.
+		const card = flat();
+		let state = initialLiveness(0);
+		state = observeFrame(state, card, 0);
+		state = observeFrame(state, card.slice(), STARTUP_GRACE_MS + FROZEN_MS);
+		expect(state.frozen).toBe(true);
+
+		state = observeFrame(state, noisier(card), STARTUP_GRACE_MS + FROZEN_MS + 100);
+		expect(state.frozen).toBe(false);
+	});
+});

--- a/packages/rppg-web/src/__tests__/captureProgress.test.ts
+++ b/packages/rppg-web/src/__tests__/captureProgress.test.ts
@@ -1,0 +1,293 @@
+import {
+	LOCK_HOLD_MS,
+	MEASURE_HOLD_MS,
+	MIN_LOCK_SAMPLES,
+	TRUST_FLOOR,
+	TRUST_FLOOR_MID,
+	TRUST_FLOOR_MIN,
+	TYPICAL_CALIBRATION_MS,
+	captureProgress,
+	restartDetected,
+	trustFloorAt,
+} from "../captureProgress";
+
+describe("the trust floor eases without a step", () => {
+	test("is continuous: no jump the reader did not cause", () => {
+		// The staircase moved the floor by 0.05 twice, which multiplied the ring's
+		// confidence term by 1.14 and then 1.17 at two instants. Sweep it and demand
+		// that no 50ms slice moves it more than a thousandth.
+		for (let t = 0; t <= 45_000; t += 50) {
+			expect(Math.abs(trustFloorAt(t + 50) - trustFloorAt(t))).toBeLessThan(0.001);
+		}
+	});
+
+	test("never gets stricter as the capture runs", () => {
+		for (let t = 0; t <= 45_000; t += 50) {
+			expect(trustFloorAt(t + 50)).toBeLessThanOrEqual(trustFloorAt(t) + 1e-12);
+		}
+	});
+
+	test("keeps the exact standard the old schedule had at its own anchors", () => {
+		// The point of the change is the SHAPE, not the strictness. Same value at the
+		// start, same two easing points, same floor.
+		expect(trustFloorAt(0)).toBe(TRUST_FLOOR);
+		expect(trustFloorAt(-1)).toBe(TRUST_FLOOR);
+		expect(trustFloorAt(Number.NaN)).toBe(TRUST_FLOOR);
+		expect(trustFloorAt(20_000)).toBeCloseTo(TRUST_FLOOR_MID, 10);
+		expect(trustFloorAt(35_000)).toBe(TRUST_FLOOR_MIN);
+		expect(trustFloorAt(120_000)).toBe(TRUST_FLOOR_MIN);
+	});
+
+	test("actually moves, or the continuity check proves nothing", () => {
+		expect(trustFloorAt(0) - trustFloorAt(35_000)).toBeCloseTo(0.1, 10);
+	});
+});
+
+/**
+ * A NOISY capture, driven past 35 seconds.
+ *
+ * Deliberately not a clean one. Confidence creeps and sits under the strict
+ * floor, so the reading only becomes lockable once the floor has eased, which is
+ * exactly where the old staircase produced its jumps.
+ */
+function runCapture(legacy = false): number[] {
+	const out: number[] = [];
+	let maxPct = 0;
+	let heldMs = 0;
+	let sinceLock = 0;
+	let locked = false;
+	for (let t = 0; t <= 40_000; t += 100) {
+		// 300ms is the real pulse poll, so samples land at the cadence they do in the app.
+		const samples = Math.min(MIN_LOCK_SAMPLES, Math.floor(t / 300));
+		const confidence = Math.min(0.33, 0.02 + t / 90_000);
+		const floor = legacy ? legacyTrustFloor(t) : trustFloorAt(t);
+		const lockReady = samples >= MIN_LOCK_SAMPLES && confidence >= floor;
+		if (!locked) {
+			heldMs = lockReady ? heldMs + 100 : Math.max(0, heldMs - 100);
+			if (heldMs >= MEASURE_HOLD_MS) locked = true;
+		} else {
+			sinceLock += 100;
+		}
+		const pct = legacy
+			? legacyProgress({ confidence, trustFloor: floor, samples, lockReady, locked })
+			: captureProgress({
+					confidence,
+					trustFloor: floor,
+					samples,
+					heldMs,
+					locked,
+					sinceLockMs: sinceLock,
+				});
+		maxPct = Math.max(maxPct, pct);
+		out.push(maxPct);
+	}
+	return out;
+}
+
+/**
+ * The formula this replaced, kept as a YARDSTICK.
+ *
+ * A "no jump larger than N points" rule needs an N, and any N picked by taste is
+ * a number that will later be relaxed by taste. So the same capture is run
+ * through the old arithmetic, and the threshold has to separate the two. If a
+ * future change makes the new curve behave like the old one, the comparison test
+ * fails and says so.
+ */
+function legacyTrustFloor(elapsedMs: number): number {
+	if (elapsedMs > 35_000) return 0.3;
+	if (elapsedMs > 20_000) return 0.35;
+	return TRUST_FLOOR;
+}
+function legacyProgress(a: {
+	confidence: number;
+	trustFloor: number;
+	samples: number;
+	lockReady: boolean;
+	locked: boolean;
+}): number {
+	const readiness = Math.min(
+		1,
+		Math.min(a.confidence / a.trustFloor, a.samples / MIN_LOCK_SAMPLES),
+	);
+	const raw = Math.round(readiness * 100);
+	const capped = a.locked ? 100 : a.lockReady ? 99 : Math.min(raw, 95);
+	return capped / 100;
+}
+
+/**
+ * The biggest single-tick move, once the bar is already off zero.
+ *
+ * Both values stay in the 0..1 scale until the return. The first version of this
+ * compared a raw delta against one already multiplied by 100, so after the first
+ * tick nothing could ever beat it: it reported the worst jump in a capture that
+ * genuinely leaps nine points as 1.0. A unit slip in a measuring instrument reads
+ * exactly like a clean result.
+ */
+function worstTick(v: number[]): { points: number; atMs: number } {
+	let worst = 0;
+	let atMs = 0;
+	for (let i = 1; i < v.length; i++) {
+		if (v[i - 1] <= 0) continue;
+		const step = v[i] - v[i - 1];
+		if (step > worst) {
+			worst = step;
+			atMs = i * 100;
+		}
+	}
+	return { points: worst * 100, atMs };
+}
+
+describe("the ring fills without jumping or stalling at a magic number", () => {
+	test("never moves backwards", () => {
+		const v = runCapture();
+		for (let i = 1; i < v.length; i++) expect(v[i]).toBeGreaterThanOrEqual(v[i - 1]);
+	});
+
+	test("never jumps once it is moving", () => {
+		/**
+		 * Measured from the moment the bar is off zero. The first movement is a step
+		 * by nature (no accepted samples, then one) and it is CAUSED, which is the
+		 * distinction this rule is about: the complaint was a bar moving for no reason
+		 * the reader could see, not a bar starting.
+		 */
+		const w = worstTick(runCapture());
+		expect(w.points).toBeLessThan(3);
+	});
+
+	test("and the formula it replaced DID jump, so that bar means something", () => {
+		// The yardstick. Three points is not a taste: it is comfortably under what the
+		// old arithmetic does to the identical capture, and comfortably above a single
+		// new sample's honest contribution.
+		const old = worstTick(runCapture(true));
+		const now = worstTick(runCapture());
+		// Measured: the old curve's worst tick is 9.0 points, at 20,100ms, which is
+		// the staircase to the millisecond. The new one's is 2.2, at 600ms, which is
+		// the second sample landing.
+		expect(old.points).toBeGreaterThan(5);
+		expect(old.atMs).toBeGreaterThan(19_000);
+		expect(old.points).toBeGreaterThan(now.points * 2);
+	});
+
+	test("starts because a sample arrived, not because a clock ticked", () => {
+		// The anchor for the exclusion above: the first movement must coincide with
+		// the first accepted sample, so "ignore the first step" cannot hide a jump.
+		const v = runCapture();
+		const firstMove = v.findIndex((x) => x > 0);
+		expect(firstMove).toBeGreaterThan(0);
+		// Samples land every 300ms in this model; the first is at t = 300ms.
+		expect(firstMove * 100).toBe(300);
+	});
+
+	test("has no 95 clamp and no 99 landing pad", () => {
+		// 95 was not a place a reading was ever AT: it was a parking space invented
+		// because 100 had to mean something else.
+		const v = runCapture();
+		expect(v.filter((x) => Math.abs(x - 0.95) < 1e-9)).toHaveLength(0);
+		expect(v.filter((x) => Math.abs(x - 0.99) < 1e-9)).toHaveLength(0);
+	});
+
+	test("reaches exactly 1 on the tick the capture commits, and not before", () => {
+		expect(Math.max(...runCapture())).toBe(1);
+		// One tick short of the landing is not done.
+		expect(
+			captureProgress({
+				confidence: 1,
+				trustFloor: TRUST_FLOOR,
+				samples: 99,
+				heldMs: MEASURE_HOLD_MS,
+				locked: true,
+				sinceLockMs: LOCK_HOLD_MS - 100,
+			}),
+		).toBeLessThan(1);
+	});
+
+	test("shows the two holds rather than sitting still through them", () => {
+		// 2.1 seconds of real work used to happen with the bar parked at 99.
+		const beforeHold = captureProgress({
+			confidence: 1,
+			trustFloor: TRUST_FLOOR,
+			samples: MIN_LOCK_SAMPLES,
+			heldMs: 0,
+			locked: false,
+			sinceLockMs: 0,
+		});
+		const midHold = captureProgress({
+			confidence: 1,
+			trustFloor: TRUST_FLOOR,
+			samples: MIN_LOCK_SAMPLES,
+			heldMs: MEASURE_HOLD_MS / 2,
+			locked: false,
+			sinceLockMs: 0,
+		});
+		const landing = captureProgress({
+			confidence: 1,
+			trustFloor: TRUST_FLOOR,
+			samples: MIN_LOCK_SAMPLES,
+			heldMs: MEASURE_HOLD_MS,
+			locked: true,
+			sinceLockMs: LOCK_HOLD_MS / 2,
+		});
+		expect(midHold).toBeGreaterThan(beforeHold);
+		expect(landing).toBeGreaterThan(midHold);
+	});
+
+	test("moves on BOTH terms at once, not on whichever is behind", () => {
+		// A `min` means exactly one term is moving the bar at any moment, so the fill
+		// rate visibly changes slope when the binding term swaps. With a geometric
+		// mean, improving either one always shows.
+		const base = {
+			trustFloor: TRUST_FLOOR,
+			heldMs: 0,
+			locked: false,
+			sinceLockMs: 0,
+		};
+		const start = captureProgress({ ...base, confidence: 0.2, samples: 9 });
+		const moreConfidence = captureProgress({ ...base, confidence: 0.3, samples: 9 });
+		const moreSamples = captureProgress({ ...base, confidence: 0.2, samples: 14 });
+		expect(moreConfidence).toBeGreaterThan(start);
+		expect(moreSamples).toBeGreaterThan(start);
+	});
+
+	test("cannot claim done on one term alone", () => {
+		const base = { trustFloor: TRUST_FLOOR, heldMs: 0, locked: false, sinceLockMs: 0 };
+		expect(captureProgress({ ...base, confidence: 9, samples: 0 })).toBe(0);
+		expect(captureProgress({ ...base, confidence: 0, samples: 999 })).toBe(0);
+	});
+
+	test("survives nonsense inputs instead of painting NaN", () => {
+		const bad = captureProgress({
+			confidence: Number.NaN,
+			trustFloor: 0,
+			samples: -5,
+			heldMs: Number.NaN,
+			locked: false,
+			sinceLockMs: Number.NaN,
+		});
+		expect(Number.isFinite(bad)).toBe(true);
+		expect(bad).toBe(0);
+	});
+
+	test("is not vacuous: this capture really does cross both old boundaries", () => {
+		const v = runCapture();
+		expect(v[0]).toBeLessThan(0.05);
+		expect(v[v.length - 1]).toBe(1);
+	});
+
+	test("budgets the time the screen promises", () => {
+		expect(TYPICAL_CALIBRATION_MS).toBe(10_000);
+	});
+});
+
+describe("the calibrator restarting is noticed", () => {
+	test("sees the sample count collapse", () => {
+		// The SDK empties its buffer after ten rejects in a row before sample 18.
+		expect(restartDetected(0, 12)).toBe(true);
+		expect(restartDetected(11, 12)).toBe(true);
+	});
+
+	test("does not cry restart on ordinary progress", () => {
+		expect(restartDetected(12, 12)).toBe(false);
+		expect(restartDetected(13, 12)).toBe(false);
+		expect(restartDetected(0, 0)).toBe(false);
+	});
+});

--- a/packages/rppg-web/src/__tests__/exposureFit.test.ts
+++ b/packages/rppg-web/src/__tests__/exposureFit.test.ts
@@ -1,0 +1,25 @@
+import { fitExposureResponse } from "../exposureFit";
+
+describe("fitExposureResponse", () => {
+	test("is null with no previous sample", () => {
+		expect(fitExposureResponse(null, { compensation: 1, luma: 0.3 })).toBeNull();
+	});
+
+	test("computes Δluma / Δcompensation for a real pair", () => {
+		const prev = { compensation: 0, luma: 0.2 };
+		const curr = { compensation: 1, luma: 0.5 };
+		expect(fitExposureResponse(prev, curr)).toBeCloseTo(0.3, 5);
+	});
+
+	test("is null when the compensation barely changed (unsafe to divide by)", () => {
+		const prev = { compensation: 0, luma: 0.2 };
+		const curr = { compensation: 0.02, luma: 0.3 };
+		expect(fitExposureResponse(prev, curr)).toBeNull();
+	});
+
+	test("is null on non-finite input", () => {
+		const prev = { compensation: 0, luma: 0.2 };
+		expect(fitExposureResponse(prev, { compensation: Number.NaN, luma: 0.3 })).toBeNull();
+		expect(fitExposureResponse({ compensation: 0, luma: Number.NaN }, prev)).toBeNull();
+	});
+});

--- a/packages/rppg-web/src/__tests__/hrvSampleTrust.test.ts
+++ b/packages/rppg-web/src/__tests__/hrvSampleTrust.test.ts
@@ -1,0 +1,26 @@
+import { HRV_TRUST_QUALITY_MIN, trustedHrvSample } from "../hrvSampleTrust";
+
+describe("trustedHrvSample", () => {
+	test("withholds the HRV value below the trust floor, at the exact boundary", () => {
+		expect(trustedHrvSample(55, HRV_TRUST_QUALITY_MIN - 0.01)).toBeNull();
+		expect(trustedHrvSample(55, HRV_TRUST_QUALITY_MIN)).toBe(55);
+	});
+
+	test("is stricter than the BPM gathering floor (0.24) — that is the whole point", () => {
+		// A sample that passes BPM gathering can still be withheld for HRV.
+		expect(HRV_TRUST_QUALITY_MIN).toBeGreaterThan(0.24);
+		expect(trustedHrvSample(70, 0.24)).toBeNull();
+		expect(trustedHrvSample(70, 0.3)).toBeNull();
+	});
+
+	test("never invents a value: null in is null out, at any quality", () => {
+		expect(trustedHrvSample(null, 1)).toBeNull();
+		expect(trustedHrvSample(null, 0)).toBeNull();
+	});
+
+	test("passes the reading through unchanged once trusted — never rescales or clamps here", () => {
+		// Range clamping already happens once, upstream. Doing it again here
+		// would be a second source of truth for the same rule.
+		expect(trustedHrvSample(123.456, 0.9)).toBe(123.456);
+	});
+});

--- a/packages/rppg-web/src/__tests__/motionIndex.test.ts
+++ b/packages/rppg-web/src/__tests__/motionIndex.test.ts
@@ -1,0 +1,39 @@
+import { landmarkMotion } from "../motionIndex";
+
+const still = (n: number) => Array.from({ length: n }, (_, i) => ({ x: i / n, y: 0.5, z: 0 }));
+
+describe("landmarkMotion", () => {
+	test("is 0 when nothing moved", () => {
+		const frame = still(468);
+		expect(landmarkMotion(frame, frame)).toBe(0);
+	});
+
+	test("is 0 when either frame is missing (no face, not maximum motion)", () => {
+		const frame = still(468);
+		expect(landmarkMotion(null, frame)).toBe(0);
+		expect(landmarkMotion(frame, null)).toBe(0);
+		expect(landmarkMotion(null, null)).toBe(0);
+	});
+
+	test("is 0 when landmark counts disagree (a dropped/re-acquired face, not motion)", () => {
+		expect(landmarkMotion(still(468), still(1))).toBe(0);
+	});
+
+	test("rises with real displacement and saturates at 1", () => {
+		const prev = still(10);
+		const smallShift = prev.map((p) => ({ ...p, x: p.x + 0.002 }));
+		const bigShift = prev.map((p) => ({ ...p, x: p.x + 0.5 }));
+		const small = landmarkMotion(prev, smallShift);
+		const big = landmarkMotion(prev, bigShift);
+		expect(small).toBeGreaterThan(0);
+		expect(small).toBeLessThan(1);
+		expect(big).toBe(1);
+		expect(big).toBeGreaterThan(small);
+	});
+
+	test("ignores z (noisier than x/y and not a signal of visible motion)", () => {
+		const prev = still(10);
+		const zOnly = prev.map((p) => ({ ...p, z: p.z + 5 }));
+		expect(landmarkMotion(prev, zOnly)).toBe(0);
+	});
+});

--- a/packages/rppg-web/src/calibration.ts
+++ b/packages/rppg-web/src/calibration.ts
@@ -1,0 +1,77 @@
+/**
+ * The stage machine a reading moves through during capture — pure state
+ * logic, no copy or presentation. Consuming apps map each stage to their own
+ * label/tone (work-framing vs. recovery-framing genuinely differ per app;
+ * see elata-bio-sdk#405/#24), but the ORDER these stages resolve in is the
+ * same drift-prone logic every consumer needs, so only the stage machine
+ * itself moves here.
+ */
+
+export type CalibrationStage =
+	| "ready"
+	| "paused"
+	| "adapting-light"
+	| "positioning"
+	| "restarting"
+	| "acquiring"
+	| "calibrating"
+	| "measuring"
+	| "locked";
+
+/**
+ * Staged scan: adapt to the room, get set up, then take the reading.
+ *
+ * `adapting-light` comes FIRST and wins over everything except pause/lock: for
+ * a brief window after arming, the app is still ramping its own fill-light and
+ * the camera's exposure toward a stable reading of the room, and samples taken
+ * during that ramp are the ones that come back "too high" — the light itself
+ * was still changing under them. During this window nothing is gathered and
+ * no advice is given, because there is nothing for the READER to fix; the app
+ * is still adjusting itself.
+ *
+ * After that: a weak signal *or* a face that isn't framed is `positioning`,
+ * show the actionable fix (more light / lower your face / hold still), no
+ * progress, no vitals. Once conditions are good we're `acquiring` (warming up
+ * to the first beat), then `calibrating` (a clean read building toward
+ * trust), then `measuring` (the read is trustworthy and framed, we're
+ * capturing the clean reading to commit). Order: pause wins, then a completed
+ * lock, then the light-adaptation window, then bad conditions (always more
+ * useful than a stale number), then the trustworthy capture, then build-up;
+ * otherwise warming up.
+ */
+export function calibrationStage(args: {
+	paused: boolean;
+	locked: boolean;
+	conditionsGood: boolean;
+	trustworthy: boolean;
+	progressPct: number;
+	/** False while the capture is held for the walkthrough: nothing is being
+	 *  measured yet, and the stage must SAY so ('ready'), because a ring that
+	 *  reads "getting a clear signal" while held is calibration to the person
+	 *  watching, whatever the internals do. */
+	armed?: boolean;
+	/**
+	 * The calibrator discarded its samples and is building again.
+	 *
+	 * Given a stage of its own because the alternative is what shipped: the ring
+	 * freezes for five seconds or more with a perfectly normal label under it, and
+	 * a bar that has stopped moving for no stated reason is the thing the owner
+	 * called laggy. The state is real, so it gets a name.
+	 */
+	restarted?: boolean;
+	/** Still inside the ambient-light warm-up window since arming. No sample
+	 *  is gathered while this holds. */
+	adaptingLight?: boolean;
+}): CalibrationStage {
+	if (args.armed === false) return "ready";
+	if (args.paused) return "paused";
+	if (args.locked) return "locked";
+	if (args.adaptingLight) return "adapting-light";
+	// Bad conditions still win. "Hold still, more light" is something the reader can
+	// act on; "starting again" is not, so it must never displace advice.
+	if (!args.conditionsGood) return "positioning";
+	if (args.restarted) return "restarting";
+	if (args.trustworthy) return "measuring";
+	if (args.progressPct > 0) return "calibrating";
+	return "acquiring";
+}

--- a/packages/rppg-web/src/cameraLiveness.ts
+++ b/packages/rppg-web/src/cameraLiveness.ts
@@ -1,0 +1,144 @@
+/**
+ * Is the camera actually sending a picture?
+ *
+ * ## The question I kept asking wrong
+ *
+ * The owner reported a "camera off" mark in the preview five times. I shipped a
+ * status word, a status glyph, a video `poster`, an opaque cover, and finally
+ * moved the whole preview to a `<canvas>` so there was no media element left to
+ * decorate. It survived all five, which ruled out every explanation involving
+ * our page: the mark arrives INSIDE the pixels. His machine substitutes a
+ * "camera is off" card for the camera's output, and we faithfully draw it.
+ *
+ * Then I asked the wrong question a sixth time. I checked whether the frame was
+ * DARK, and hid it below a threshold. That is wrong twice over: his room is
+ * genuinely dark, so it hid his working face; and the substituted card is not
+ * black, it has a bright glyph on it, so it sailed over the threshold anyway.
+ *
+ * Darkness is a property of the room. It is legitimate, and a dark picture is
+ * still a picture. The real question is whether a sensor is on the other end.
+ *
+ * ## The rule
+ *
+ * **A real sensor is never still.** Every camera ever built produces noise: heat
+ * in the photosites, read noise in the amplifier, dither in the encoder. Point a
+ * webcam at a blank wall in a pitch-dark room and consecutive frames still
+ * differ, by a count or two, somewhere. That is physics, not a feature, so it
+ * holds on every camera on every machine without us knowing anything about the
+ * hardware.
+ *
+ * A substituted placeholder is one still image. It is bit-identical every single
+ * frame, because it is literally the same bitmap being handed out again.
+ *
+ * So: "has any part of this picture changed in the last two seconds?" No
+ * threshold to tune, no brightness to guess at, nothing about his room.
+ *
+ * ## Why elapsed time rather than a count of frames
+ *
+ * Webcams collapse their frame rate in low light: 30fps in daylight, 5fps or
+ * less in a dark room, while an animation frame keeps firing at 60Hz. Counting
+ * identical frames would therefore accuse a slow-but-working camera of being
+ * dead precisely in the conditions he uses it in. Two seconds without one
+ * changed sample is not a slow camera; it is no camera.
+ */
+
+/**
+ * Edge of the sample grid. 16x16 = 256 pixels spread across the frame.
+ *
+ * Sampled with image smoothing OFF, which matters more than the size: a smoothed
+ * downsample AVERAGES about a thousand source pixels per output pixel, which
+ * divides sensor noise by ~35 and quantises it away to a constant. That would
+ * make a live camera look frozen, which is the exact false accusation this
+ * module exists to avoid. Nearest-neighbour picks individual real pixels and
+ * keeps their noise.
+ */
+export const SIGNATURE_EDGE = 16;
+
+/**
+ * No change for this long and the picture is not coming from a sensor.
+ *
+ * Long enough to clear the slowest plausible frame rate several times over,
+ * short enough that he is told before he has spent a whole reading staring at a
+ * ring that cannot succeed.
+ */
+export const FROZEN_MS = 2000;
+
+/**
+ * No verdict of `frozen` before this much time has passed since the FIRST
+ * sample, however still the picture looks.
+ *
+ * Reported 2026-08-02: "keeps showing camera off icon through calibration when
+ * it is dark initially." Some webcam drivers hand back a duplicate of the very
+ * first captured buffer for the first few frames while the sensor's real
+ * exposure is still being read out, especially at the long shutter times a
+ * dark room forces. That duplicate is bit-identical, which is exactly the
+ * signal this module was built to catch, and 2s is not long enough to tell a
+ * driver's startup artifact apart from a genuinely covered lens. It always was
+ * "initially," never mid-session, which is the startup tell.
+ *
+ * Twice FROZEN_MS: generous enough to clear a slow driver's warm-up, still
+ * short enough that a camera covered from the very first frame is caught
+ * within a few seconds of arming rather than never.
+ */
+export const STARTUP_GRACE_MS = FROZEN_MS * 2;
+
+export type Liveness = {
+  /** The last picture we saw, or null before the first sample. */
+  readonly signature: readonly number[] | null;
+  /** When the picture last differed from the one before it. */
+  readonly changedAt: number;
+  /** When the first sample was taken. Fixed for the life of one session, so
+   *  the startup grace is measured from arming, not from the last change. */
+  readonly startedAt: number;
+  /** Nothing has changed for {@link FROZEN_MS}, and we are past
+   *  {@link STARTUP_GRACE_MS}. */
+  readonly frozen: boolean;
+};
+
+export function initialLiveness(nowMs: number): Liveness {
+  return { signature: null, changedAt: nowMs, startedAt: nowMs, frozen: false };
+}
+
+/**
+ * Reduce a sampled RGBA buffer to the values we compare.
+ *
+ * Alpha is dropped: it is 255 for every pixel of every camera frame, so keeping
+ * it would be a quarter of the comparison spent on a constant.
+ */
+export function signatureOf(pixels: ArrayLike<number>): number[] {
+  const out: number[] = [];
+  for (let i = 0; i + 2 < pixels.length; i += 4) {
+    out.push(pixels[i], pixels[i + 1], pixels[i + 2]);
+  }
+  return out;
+}
+
+/** Exact equality. One count of difference in one sample is a living camera. */
+export function sameSignature(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
+ * Fold one sampled frame into the running judgement.
+ *
+ * The clock is passed in rather than read, so the whole rule is testable without
+ * a camera, a dark room, or a timer.
+ */
+export function observeFrame(
+  prev: Liveness,
+  signature: readonly number[],
+  nowMs: number,
+): Liveness {
+  if (prev.signature === null || !sameSignature(prev.signature, signature)) {
+    return { signature, changedAt: nowMs, startedAt: prev.startedAt, frozen: false };
+  }
+  const pastStartupGrace = nowMs - prev.startedAt >= STARTUP_GRACE_MS;
+  return {
+    signature: prev.signature,
+    changedAt: prev.changedAt,
+    startedAt: prev.startedAt,
+    frozen: pastStartupGrace && nowMs - prev.changedAt >= FROZEN_MS,
+  };
+}

--- a/packages/rppg-web/src/cameraLiveness.ts
+++ b/packages/rppg-web/src/cameraLiveness.ts
@@ -100,6 +100,22 @@ export function initialLiveness(nowMs: number): Liveness {
 }
 
 /**
+ * Has enough time passed since the first sample to trust a stillness verdict?
+ *
+ * Pulled out of `observeFrame` so a caller that has NOT received a single
+ * frame yet can apply the same grace period. `observeFrame` can only judge
+ * "same picture as before", which needs a frame to exist in the first place —
+ * a track that delivers literally zero frames (getUserMedia resolves,
+ * getSettings() reports a plausible negotiation, but no decodable frame ever
+ * arrives — measured on real hardware in peak-app via its cameraSweep.ts) is
+ * invisible to it. That case needs this same threshold applied to
+ * elapsed-time-with-no-frame instead of elapsed-time-with-no-CHANGE.
+ */
+export function pastStartupGrace(startedAtMs: number, nowMs: number): boolean {
+  return nowMs - startedAtMs >= STARTUP_GRACE_MS;
+}
+
+/**
  * Reduce a sampled RGBA buffer to the values we compare.
  *
  * Alpha is dropped: it is 255 for every pixel of every camera frame, so keeping
@@ -134,11 +150,11 @@ export function observeFrame(
   if (prev.signature === null || !sameSignature(prev.signature, signature)) {
     return { signature, changedAt: nowMs, startedAt: prev.startedAt, frozen: false };
   }
-  const pastStartupGrace = nowMs - prev.startedAt >= STARTUP_GRACE_MS;
+  const past = pastStartupGrace(prev.startedAt, nowMs);
   return {
     signature: prev.signature,
     changedAt: prev.changedAt,
     startedAt: prev.startedAt,
-    frozen: pastStartupGrace && nowMs - prev.changedAt >= FROZEN_MS,
+    frozen: past && nowMs - prev.changedAt >= FROZEN_MS,
   };
 }

--- a/packages/rppg-web/src/captureProgress.ts
+++ b/packages/rppg-web/src/captureProgress.ts
@@ -1,0 +1,140 @@
+/**
+ * How full the calibration ring is, and how strict the reading is being.
+ *
+ * This is the arithmetic behind a number the reader watches for ten seconds —
+ * every symptom addressed below was reported by a real user and none of it
+ * was visible from reading a component alone.
+ */
+
+import { DEFAULT_BASELINE_CALIBRATOR_CONFIG } from "./baselineCalibrator";
+
+/**
+ * Minimum capture confidence to treat a reading as real. Below it, keep the
+ * previous metrics and ask for a recapture rather than rendering a garbage
+ * score, or letting it skew a baseline / insights.
+ */
+export const TRUST_FLOOR = 0.4;
+
+/** Minimum accepted samples before a lock, ~5.4s at the 300ms poll. */
+export const MIN_LOCK_SAMPLES = DEFAULT_BASELINE_CALIBRATOR_CONFIG.minForStability;
+
+/** Sustained good window required before the reading is taken. */
+export const MEASURE_HOLD_MS = 1200;
+
+/** The landing: the finished reading stays on screen this long before committing. */
+export const LOCK_HOLD_MS = 900;
+
+/** Where the trust floor eases to, and when. Same numbers the staircase used. */
+export const TRUST_FLOOR_MID = 0.35;
+export const TRUST_FLOOR_MIN = 0.3;
+export const TRUST_EASE_MID_MS = 20_000;
+export const TRUST_EASE_END_MS = 35_000;
+
+/**
+ * The confidence a reading must reach, at `elapsedMs` into the capture.
+ *
+ * Continuous, where it used to be a staircase:
+ *
+ *     if (elapsed > 35_000) setTrustFloor(0.3);
+ *     else if (elapsed > 20_000) setTrustFloor(0.35);
+ *
+ * The floor is the denominator of the ring's confidence term, so those two `if`s
+ * multiplied the bar by 1.14 and then by 1.17 at two instants, with nothing about
+ * the reading having changed. On a noisy read, where confidence is the term
+ * holding everything up, that is a bar sitting still and then leaping twenty
+ * points because a clock ticked. It is the "flaky, jumps around" report.
+ *
+ * The three anchors are exactly the old schedule's values at exactly the times it
+ * reached them, so the capture is no stricter at the start and no more permissive
+ * at the end than it has ever been. The only change is that it is drawn rather
+ * than stepped.
+ */
+export function trustFloorAt(elapsedMs: number): number {
+	if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return TRUST_FLOOR;
+	if (elapsedMs >= TRUST_EASE_END_MS) return TRUST_FLOOR_MIN;
+	if (elapsedMs <= TRUST_EASE_MID_MS) {
+		return TRUST_FLOOR + (TRUST_FLOOR_MID - TRUST_FLOOR) * (elapsedMs / TRUST_EASE_MID_MS);
+	}
+	const p = (elapsedMs - TRUST_EASE_MID_MS) / (TRUST_EASE_END_MS - TRUST_EASE_MID_MS);
+	return TRUST_FLOOR_MID + (TRUST_FLOOR_MIN - TRUST_FLOOR_MID) * p;
+}
+
+/**
+ * How long a typical capture takes to become lockable.
+ *
+ * Not invented: it is the number a capture screen prints under its heading,
+ * and a consuming app's own test pins the two together so the promise and
+ * the budget below cannot drift apart.
+ */
+export const TYPICAL_CALIBRATION_MS = 10_000;
+
+const TOTAL_MS = TYPICAL_CALIBRATION_MS + MEASURE_HOLD_MS + LOCK_HOLD_MS;
+/** Shares of the bar, DERIVED from the real durations rather than chosen. */
+export const READINESS_SHARE = TYPICAL_CALIBRATION_MS / TOTAL_MS;
+export const MEASURE_SHARE = MEASURE_HOLD_MS / TOTAL_MS;
+export const COMMIT_SHARE = LOCK_HOLD_MS / TOTAL_MS;
+
+const clamp01 = (v: number) => (Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : 0);
+
+export interface CaptureProgressInput {
+	/** The calibrator's confidence, already high-watered by the caller. */
+	confidence: number;
+	/** From {@link trustFloorAt}. */
+	trustFloor: number;
+	/** Accepted samples so far. */
+	samples: number;
+	/** Accumulated sustained lock-ready time. */
+	heldMs: number;
+	locked: boolean;
+	/** Time since the lock, for the landing. */
+	sinceLockMs: number;
+}
+
+/**
+ * How much of the reading is done, 0..1, INCLUDING both holds.
+ *
+ * What this replaces had three faults and they compounded:
+ *
+ *  1. `Math.min(conf / floor, n / MIN_LOCK_SAMPLES)`. A `min` means exactly one
+ *     term is moving the bar at any moment, so the fill rate visibly changed
+ *     slope the instant the binding term swapped. Nothing on screen explained it.
+ *  2. `locked ? 100 : lockReady ? 99 : Math.min(raw, 95)`. 95 is not a place a
+ *     reading is ever AT: it was a parking space invented because 100 had to mean
+ *     something else. Leaving it was a jump of twenty to forty points.
+ *  3. The two holds were invisible. The bar sat at 99 through 2.1 seconds of real
+ *     work, which is the hang at the end of every capture.
+ *
+ * So: no `min`, no clamp, and the holds are part of the same number.
+ *
+ * The two calibration terms combine with a GEOMETRIC MEAN. It is 1 exactly when
+ * both are 1, so the bar still cannot claim done early; it is monotone in each;
+ * and unlike `min` it MOVES on both at all times, which is the fix for the slope
+ * change. The three shares sum to 1, so the bar reaches 1 exactly when the
+ * landing completes, which is when the capture commits.
+ */
+export function captureProgress(i: CaptureProgressInput): number {
+	const conf = clamp01(i.trustFloor > 0 ? i.confidence / i.trustFloor : 0);
+	const enough = clamp01(i.samples / MIN_LOCK_SAMPLES);
+	const readiness = Math.sqrt(conf * enough);
+	const hold = clamp01(i.heldMs / MEASURE_HOLD_MS);
+	const commit = i.locked ? clamp01(i.sinceLockMs / LOCK_HOLD_MS) : 0;
+	return clamp01(READINESS_SHARE * readiness + MEASURE_SHARE * hold + COMMIT_SHARE * commit);
+}
+
+/**
+ * Has the calibrator thrown its samples away and started over?
+ *
+ * The SDK does this deliberately: after ten rejects in a row before sample 18 it
+ * empties its buffer, so an early bad average cannot wedge the whole capture
+ * (`baselineCalibrator.ts`). A DECREASING sample count is the only observable of
+ * it, and nothing else in that class can decrease one.
+ *
+ * It matters because of what the reader sees: the count collapses to zero, the
+ * ring's high-water mark holds the number where it was, and the bar then sits
+ * perfectly still for five seconds or more with nothing saying why. That silence
+ * is the "laggy, stuck" half of the report. The ring is right not to retreat; it
+ * was wrong to say nothing.
+ */
+export function restartDetected(samples: number, previousSamples: number): boolean {
+	return samples < previousSamples;
+}

--- a/packages/rppg-web/src/exposureFit.ts
+++ b/packages/rppg-web/src/exposureFit.ts
@@ -1,0 +1,52 @@
+/**
+ * Camera exposure response fitting: given two (compensation, luma) samples,
+ * estimate the local sensitivity (Δluma / Δcompensation) so a consumer can
+ * solve directly for a target luma instead of guessing a proportional nudge.
+ *
+ * This is the measurement the "solve directly for the target" correction in
+ * an app's own exposure-tuning decision is built on — the same principle the
+ * rPPG exposure-control literature uses (fit the camera's actual response,
+ * then invert it), scaled down from a dedicated multi-frame-per-second
+ * scheme to a once-a-second luma poll: no new frames are sampled, this just
+ * uses the two most recent (compensation, luma) pairs a caller already has.
+ *
+ * Honest limit: unlike a study that locks exposure to isolate the
+ * measurement, a consuming app's camera keeps running continuous
+ * autoexposure, so the sensor's own AE algorithm can partly re-compensate
+ * between samples, and ambient light can genuinely change for reasons
+ * unrelated to the requested compensation. The fit is a best-effort local
+ * estimate, not a controlled measurement — callers should guard against a
+ * nonsensical (near-zero or inverted-sign) result rather than trusting every
+ * fit blindly.
+ */
+
+/** One (compensation, resulting luma) pair, for {@link fitExposureResponse}. */
+export interface ExposureSample {
+	compensation: number;
+	luma: number;
+}
+
+/**
+ * Minimum |Δcompensation| (EV) between two samples before a slope is trusted.
+ * Below this, rounding/step granularity dominates the ratio and a near-zero
+ * denominator can produce a wildly wrong slope from two samples that barely
+ * differ.
+ */
+const MIN_FIT_DELTA = 0.05;
+
+/**
+ * Local response slope (Δluma / Δcompensation) between two samples, or null
+ * when there isn't a trustworthy pair yet: no previous sample, non-finite
+ * input, or a compensation delta too small to divide by safely.
+ */
+export function fitExposureResponse(
+	prev: ExposureSample | null,
+	curr: ExposureSample,
+): number | null {
+	if (!prev) return null;
+	if (!Number.isFinite(prev.compensation) || !Number.isFinite(prev.luma)) return null;
+	if (!Number.isFinite(curr.compensation) || !Number.isFinite(curr.luma)) return null;
+	const dComp = curr.compensation - prev.compensation;
+	if (Math.abs(dComp) < MIN_FIT_DELTA) return null;
+	return (curr.luma - prev.luma) / dComp;
+}

--- a/packages/rppg-web/src/hrvSampleTrust.ts
+++ b/packages/rppg-web/src/hrvSampleTrust.ts
@@ -1,0 +1,46 @@
+/**
+ * Should THIS sample's HRV reading be fed into the baseline calibrator?
+ *
+ * Reported 2026-08-02: "hrv measurement seems off and either way too high or
+ * low." Traced as far as this codebase can trace it: `hrv_rmssd` comes
+ * straight from `@elata-biosciences/rppg-web` (the SDK's own doc calls it
+ * "Experimental"), range-clamped in `rppg.ts` and otherwise passed through
+ * unmodified — no bug in the number itself, and nothing here can improve the
+ * vendored SDK's estimate.
+ *
+ * What IS this codebase's to fix: the SDK's `BaselineCalibrator` rejects
+ * outlier SAMPLES by BPM distance only (`outlierBpm`) — a frame can pass that
+ * gate on a perfectly good beat-rate estimate while its HRV figure, which
+ * needs precise beat-to-BEAT timing rather than just an average rate, is
+ * garbage. rMSSD is far more sensitive to a single misdetected beat than BPM
+ * is, so the SAME quality floor that is fine for gathering BPM (see
+ * `qualityOk` in BaselineCapture.tsx, 0.24) is not strict enough to trust
+ * that sample's HRV specifically.
+ *
+ * The fix costs nothing to the BPM path: BPM keeps gathering at its existing
+ * floor, and only the HRV VALUE for a marginal-quality sample is withheld
+ * (pushed as null) rather than the whole sample being dropped. The
+ * calibrator's own trimmed-median still runs over whatever HRV values DO
+ * arrive; this only raises the bar for what gets to vote.
+ *
+ * Honest limit: this is a best-effort mitigation, not a verified fix. There
+ * is no ground-truth ECG reference in this codebase to confirm accuracy
+ * against, only the (well-founded, but unmeasured here) reasoning above.
+ */
+
+/**
+ * Higher than the 0.24 floor BPM gathers at. Not derived from a measurement —
+ * there is no way to derive it from one without reference HRV data — chosen
+ * as a meaningfully stricter bar (avoids the noisiest third of the accepted-
+ * for-BPM range) rather than an arbitrary-looking number close to the BPM
+ * floor that would barely change anything.
+ */
+export const HRV_TRUST_QUALITY_MIN = 0.4;
+
+/** The HRV value to actually push into the calibrator for this sample: the
+ *  reading itself if the signal is strong enough to trust it for HRV
+ *  specifically, otherwise null (BPM still gathers from this sample). */
+export function trustedHrvSample(hrvRmssd: number | null, quality: number): number | null {
+  if (hrvRmssd == null) return null;
+  return quality >= HRV_TRUST_QUALITY_MIN ? hrvRmssd : null;
+}

--- a/packages/rppg-web/src/index.ts
+++ b/packages/rppg-web/src/index.ts
@@ -350,6 +350,7 @@ export {
 	SIGNATURE_EDGE,
 	initialLiveness,
 	observeFrame,
+	pastStartupGrace,
 	sameSignature,
 	signatureOf,
 } from "./cameraLiveness";

--- a/packages/rppg-web/src/index.ts
+++ b/packages/rppg-web/src/index.ts
@@ -319,6 +319,44 @@ export type {
 	RppgGatingState,
 	RppgGuidanceCode,
 } from "./rppgGating";
+// --- Reliability-gating surface (elata-bio-sdk#405): every rule that decides
+// whether an rPPG number is trustworthy enough to show, gather, or average.
+// Extracted so three independent consumer apps stop hand-copying it — see
+// resolveDisplayMetrics above and elata-bio-sdk#24 for the failure history.
+export { HRV_TRUST_QUALITY_MIN, trustedHrvSample } from "./hrvSampleTrust";
+export {
+	COMMIT_SHARE,
+	LOCK_HOLD_MS,
+	MEASURE_HOLD_MS,
+	MEASURE_SHARE,
+	MIN_LOCK_SAMPLES,
+	READINESS_SHARE,
+	TRUST_EASE_END_MS,
+	TRUST_EASE_MID_MS,
+	TRUST_FLOOR,
+	TRUST_FLOOR_MID,
+	TRUST_FLOOR_MIN,
+	TYPICAL_CALIBRATION_MS,
+	captureProgress,
+	restartDetected,
+	trustFloorAt,
+} from "./captureProgress";
+export type { CaptureProgressInput } from "./captureProgress";
+export { calibrationStage } from "./calibration";
+export type { CalibrationStage } from "./calibration";
+export {
+	FROZEN_MS,
+	STARTUP_GRACE_MS,
+	SIGNATURE_EDGE,
+	initialLiveness,
+	observeFrame,
+	sameSignature,
+	signatureOf,
+} from "./cameraLiveness";
+export type { Liveness } from "./cameraLiveness";
+export { landmarkMotion } from "./motionIndex";
+export { fitExposureResponse } from "./exposureFit";
+export type { ExposureSample } from "./exposureFit";
 export { replayBayesSession } from "./rppgReplay";
 export type {
 	ReplayEstimatorSample,

--- a/packages/rppg-web/src/motionIndex.ts
+++ b/packages/rppg-web/src/motionIndex.ts
@@ -1,0 +1,58 @@
+/**
+ * How much the face actually moved between two frames, from face-mesh landmarks.
+ *
+ * A head-box framing gate only knows whether the SDK's head BOX is centred —
+ * it says nothing about motion that keeps the box roughly in place (a nod, a
+ * tilt, talking), which is exactly the motion the rPPG literature identifies
+ * as most disruptive to signal quality (speaking and head-shake degrade HR
+ * estimation even when framing looks fine). A landmark-based index answers a
+ * different question than the box does: not "is the face positioned
+ * correctly" but "did the face just move."
+ *
+ * Deliberately NOT face-box-based and NOT limited to the frame centre — every
+ * one of the 468 mesh points contributes, so motion at the jaw or brow (which
+ * can leave the box's own centroid nearly unchanged) still registers.
+ */
+
+import type { LandmarkLike } from "./roiProfile";
+
+/**
+ * Mean per-landmark Euclidean displacement between two frames, in normalized
+ * (0..1 of frame) coordinates, scaled to roughly 0..1 for "still" through
+ * "significant movement."
+ *
+ * Only x/y are compared (see {@link LandmarkLike}): MediaPipe's z is
+ * depth-relative-to-a-reference point and far noisier frame-to-frame than
+ * x/y, so including it would inflate the score on a face that is visually
+ * still. This mirrors the literature's own convention (motion indices built
+ * from yaw/pitch/x-y landmark deltas, not raw 3D displacement).
+ *
+ * Null on either frame (no face detected, or the first frame with nothing to
+ * compare against) returns 0 — "no evidence of motion," not "maximum motion."
+ * A dropped detection is not itself motion, and treating it as such would
+ * falsely gate a capture the instant the face model has one bad frame.
+ */
+export function landmarkMotion(
+	prev: readonly LandmarkLike[] | null,
+	curr: readonly LandmarkLike[] | null,
+): number {
+	if (!prev || !curr || prev.length === 0 || curr.length !== prev.length) return 0;
+	let sum = 0;
+	for (let i = 0; i < curr.length; i++) {
+		const dx = curr[i].x - prev[i].x;
+		const dy = curr[i].y - prev[i].y;
+		sum += Math.sqrt(dx * dx + dy * dy);
+	}
+	const mean = sum / curr.length;
+	// Calibration: normal micro-jitter while genuinely still sits under ~0.001
+	// (mean per-point displacement, normalized frame units) at a 300ms poll
+	// interval; a deliberate head turn or nod is well over 0.01. 0.02 as the
+	// point where the score saturates to 1 leaves headroom above "clearly
+	// moving" for genuinely large motion, rather than clipping real variation
+	// into one bucket. Not derived from a measured dataset — a placeholder
+	// scale chosen to be well-separated from observed stillness, tightened
+	// later against real signal-quality correlation if `motion_mean` from the
+	// WASM backend and this score are ever compared side by side.
+	const SATURATE_AT = 0.02;
+	return Math.max(0, Math.min(1, mean / SATURATE_AT));
+}


### PR DESCRIPTION
## Summary

Part 1 of #[405](https://github.com/Elata-Biosciences/peak-app/issues/405) (revised): instead of a new `@elata-biosciences/rppg-core` package (the original scoping comment's proposal, superseded every consumer of this logic already depends on `rppg-web` for the camera/WASM pipeline, so a separate package would only add a second thing to keep version-compatible, without saving any consumer a dependency), this folds the reliability-gating logic in as more exports on the existing, already-depended-on `@elata-biosciences/rppg-web`. Same pattern as #26.

Three independent consumer apps (peak-app, vitality-app, neural-chat-app) each hand-copied and independently re-drifted this exact logic - see #24/#26/#[405](https://github.com/Elata-Biosciences/peak-app/issues/405).

## What moved (each with its existing test)

- `trustedHrvSample` / `HRV_TRUST_QUALITY_MIN` (`hrvSampleTrust.ts`)
- `captureProgress` / `trustFloorAt` / `restartDetected` / `TRUST_FLOOR` and its easing constants (`captureProgress.ts`) `TRUST_FLOOR` itself pulled out of peak-app's much larger `metrics.ts`, since it belongs beside its only real consumer
- `initialLiveness` / `observeFrame` / frozen-frame detection (`cameraLiveness.ts`)
- `landmarkMotion`, the #404 motion gate (`motionIndex.ts`) now typed against the SDK's own `LandmarkLike` instead of a peak-app-local type
- `fitExposureResponse`, split out of a larger `cameraTuning.ts` whose other half (`zoomFor`/`tuningFor`/`shouldRetune`) is camera-request orchestration specific to how each app talks to its own capture session, and stays local to each app

## Deliberately narrowed on one file

`calibration.ts`'s `CALIBRATION_LABEL`, `calibrationLabelTone`, and `signalTier`'s tone field are display copy and CSS tone classes, not logic only `calibrationStage()` (the actual state machine) moves. Peak's work-framing and Vitality's recovery-framing genuinely differ and were never meant to be forced into one shared surface; only the drift-prone ORDERING logic was.

## Not in this PR

- Peak-app/vitality-app migrating to consume this (separate follow-up PRs per app, once this is reviewed and published)
- #27 (found while researching this: `DisplayBpmTracker.hold()` already in this package contradicts the no-holdover design here - filed separately, zero current consumers, not blocking this PR)

## Test plan

- `tsc -p . --noEmit` - clean
- `biome lint src` - clean
- `pnpm run build` - dist compiles and Node-ESM-verifies cleanly
- Full package suite: 408/408 passing (49 suites), including 58 new tests across the 6 moved modules
- App-specific source-scan tests (checking how peak-app's own `App.tsx`/`PulseContext.tsx`/`BaselineCapture.tsx` consume these functions) did not port - the SDK has no such files; only behavioral tests moved
- Changeset added (`@elata-biosciences/rppg-web`, minor)