### PR TITLE
docs(rppg-web): remove em-dashes from this session's comments

### DIFF
--- a/.changeset/gate-reliability-into-rppg-web.md
+++ b/.changeset/gate-reliability-into-rppg-web.md
@@ -6,7 +6,7 @@ Add the reliability-gating surface: `trustedHrvSample`, `calibrationStage`,
 camera-frozen-frame detection (`initialLiveness`/`observeFrame`/etc.),
 `landmarkMotion`, and `fitExposureResponse`. Extracted from three independent
 consumer apps (peak-app, vitality-app, neural-chat-app) that had each been
-hand-copying and re-drifting this exact logic — see elata-bio-sdk#24/#26/#405.
+hand-copying and re-drifting this exact logic. See elata-bio-sdk#24/#26/#405.
 
 Deliberately excludes display copy and CSS tone classes (`CALIBRATION_LABEL`,
 `calibrationLabelTone`, `signalTier`'s tone field): each app's own framing

--- a/.changeset/multi-roi-skin-tone-weighting.md
+++ b/.changeset/multi-roi-skin-tone-weighting.md
@@ -3,7 +3,7 @@
 ---
 
 Fix `MultiRoiRppgFuser` weighting each ROI's already-CHROM-filtered pulse
-signal by that signal's own spectral SNR — Chari et al. ("Diverse R-PPG")
+signal by that signal's own spectral SNR. Chari et al. ("Diverse R-PPG")
 benchmarked this exact construction and found it increases skin-tone bias
 relative to plain unweighted spatial averaging, because darker skin's lower
 reflected light lowers post-processing SNR for a camera-noise reason

--- a/.changeset/resolve-display-metrics.md
+++ b/.changeset/resolve-display-metrics.md
@@ -3,7 +3,7 @@
 ---
 
 Add `resolveDisplayMetrics(snapshot)`, the single stateless decision for
-"what BPM/HRV should this app show right now" — a pure snapshot-in,
+"what BPM/HRV should this app show right now", a pure snapshot-in,
 decision-out mapping with no accumulator to hold a stale value past the
 point the SDK's own gating says a reading is no longer trustworthy.
 Extracted after three independent consumer apps each wrote their own
@@ -11,6 +11,6 @@ version of this decision and at least two got it wrong the same way
 (elata-bio-sdk#24, neural-chat-app#10, peak-app#404/#408).
 
 `bpm` is gated by `canPublish`/`publishBpm`. `hrvRmssd` composes that gate
-with the stricter, HRV-specific `trustedHrvSample` (elata-bio-sdk#28) —
+with the stricter, HRV-specific `trustedHrvSample` (elata-bio-sdk#28):
 beat-to-beat timing is far more fragile than an average rate, so a sample
 can clear the BPM gate and still carry a garbage HRV figure.

--- a/packages/rppg-web/src/__tests__/calibration.test.ts
+++ b/packages/rppg-web/src/__tests__/calibration.test.ts
@@ -9,7 +9,7 @@ describe("calibrationStage", () => {
 		progressPct: 0,
 	};
 
-	test('is "positioning" when conditions are not good — no progress on bad data', () => {
+	test('is "positioning" when conditions are not good: no progress on bad data', () => {
 		expect(calibrationStage({ ...base, conditionsGood: false })).toBe("positioning");
 		// Bad conditions win even after progress accrues or the read looks trusted
 		// (e.g. drifting out of frame mid-scan).
@@ -88,7 +88,7 @@ describe("calibrationStage", () => {
 		/**
 		 * Reported 2026-08-02: numbers come back too high when calibrating in the
 		 * dark, and the reading starts before the light has adapted. This stage
-		 * exists so nothing is gathered — and nothing is BLAMED ON THE READER —
+		 * exists so nothing is gathered, and nothing is BLAMED ON THE READER,
 		 * while the app's own fill-light and the camera's exposure are still
 		 * moving.
 		 */
@@ -98,7 +98,7 @@ describe("calibrationStage", () => {
 			);
 		});
 
-		test("wins over acquiring and calibrating too — any accrual during this window is what broke", () => {
+		test("wins over acquiring and calibrating too: any accrual during this window is what broke", () => {
 			expect(calibrationStage({ ...base, progressPct: 0, adaptingLight: true })).toBe(
 				"adapting-light",
 			);
@@ -110,7 +110,7 @@ describe("calibrationStage", () => {
 			).toBe("adapting-light");
 		});
 
-		test("never displaces pause or lock — those are more true than \"still adjusting\"", () => {
+		test("never displaces pause or lock: those are more true than \"still adjusting\"", () => {
 			expect(calibrationStage({ ...base, paused: true, adaptingLight: true })).toBe("paused");
 			expect(calibrationStage({ ...base, locked: true, adaptingLight: true })).toBe("locked");
 			expect(calibrationStage({ ...base, armed: false, adaptingLight: true })).toBe("ready");

--- a/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
+++ b/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
@@ -63,7 +63,7 @@ describe("a substituted still image is caught", () => {
 		// threshold, because the glyph on it is bright. It is caught by being STILL.
 		// Armed at t=14000 (an arbitrary time well after page load), so the
 		// startup grace measured from THIS session's first frame has already
-		// cleared by the time the freeze is asserted below — a mid-session
+		// cleared by the time the freeze is asserted below: a mid-session
 		// freeze, not a driver warming up.
 		// Since the very first frame of THIS session never changes, `changedAt`
 		// stays pinned to `armedAt` too, so STARTUP_GRACE_MS (the larger of the
@@ -113,7 +113,7 @@ describe("a driver warming up is not accused", () => {
 		// The anti-vacuity partner: the startup grace must not become a licence to
 		// never accuse a camera that is covered from t=0. Since the very first
 		// frame never changes, `changedAt` stays at 0 too, so STARTUP_GRACE_MS
-		// (4000ms) is the binding constraint here, not FROZEN_MS (2000ms) — by the
+		// (4000ms) is the binding constraint here, not FROZEN_MS (2000ms); by the
 		// time the grace window clears, the identical streak has already run
 		// longer than FROZEN_MS regardless.
 		const covered = flat(0);
@@ -130,7 +130,7 @@ describe("pastStartupGrace", () => {
 	test("is false before STARTUP_GRACE_MS has elapsed, true at and past it", () => {
 		// Shared by observeFrame's own frozen check and by the zero-frames-ever
 		// case a consumer (e.g. peak-app's CameraPreview.tsx) has no signature
-		// to compare and so cannot call observeFrame at all — one threshold,
+		// to compare and so cannot call observeFrame at all, one threshold,
 		// two callers.
 		expect(pastStartupGrace(1000, 1000 + STARTUP_GRACE_MS - 1)).toBe(false);
 		expect(pastStartupGrace(1000, 1000 + STARTUP_GRACE_MS)).toBe(true);

--- a/packages/rppg-web/src/__tests__/displayMetrics.test.ts
+++ b/packages/rppg-web/src/__tests__/displayMetrics.test.ts
@@ -35,7 +35,7 @@ describe("resolveDisplayMetrics", () => {
 		// The gap a reviewer caught: HRV's beat-to-beat timing is far more
 		// fragile than BPM's average rate, so a sample can clear canPublish and
 		// still carry a garbage HRV figure. trustedHrvSample owns this second,
-		// stricter gate — composed here, not re-derived.
+		// stricter gate, composed here, not re-derived.
 		const result = resolveDisplayMetrics(
 			fixture({
 				canPublish: true,
@@ -93,7 +93,7 @@ describe("resolveDisplayMetrics", () => {
 		expect(result.confidence).toBe("low");
 	});
 
-	test("has no state to hold a value past the snapshot that nulled it — two calls in a row reflect each snapshot independently", () => {
+	test("has no state to hold a value past the snapshot that nulled it: two calls in a row reflect each snapshot independently", () => {
 		// This is the property that makes the neural-chat-app bug structurally
 		// impossible here: there is no accumulator to carry a prior good value
 		// forward once canPublish goes false.

--- a/packages/rppg-web/src/__tests__/hrvSampleTrust.test.ts
+++ b/packages/rppg-web/src/__tests__/hrvSampleTrust.test.ts
@@ -6,7 +6,7 @@ describe("trustedHrvSample", () => {
 		expect(trustedHrvSample(55, HRV_TRUST_QUALITY_MIN)).toBe(55);
 	});
 
-	test("is stricter than the BPM gathering floor (0.24) — that is the whole point", () => {
+	test("is stricter than the BPM gathering floor (0.24), which is the whole point", () => {
 		// A sample that passes BPM gathering can still be withheld for HRV.
 		expect(HRV_TRUST_QUALITY_MIN).toBeGreaterThan(0.24);
 		expect(trustedHrvSample(70, 0.24)).toBeNull();
@@ -18,7 +18,7 @@ describe("trustedHrvSample", () => {
 		expect(trustedHrvSample(null, 0)).toBeNull();
 	});
 
-	test("passes the reading through unchanged once trusted — never rescales or clamps here", () => {
+	test("passes the reading through unchanged once trusted: never rescales or clamps here", () => {
 		// Range clamping already happens once, upstream. Doing it again here
 		// would be a second source of truth for the same rule.
 		expect(trustedHrvSample(123.456, 0.9)).toBe(123.456);

--- a/packages/rppg-web/src/__tests__/multiRoiFusion.test.ts
+++ b/packages/rppg-web/src/__tests__/multiRoiFusion.test.ts
@@ -94,7 +94,7 @@ describe("MultiRoiRppgFuser", () => {
 		// several samples before it outputs anything non-zero either way).
 		const fs = 30;
 		// updateEverySeconds huge so weights never leave their equal starting
-		// point mid-run — isolates the RGB-vs-post-CHROM blending question from
+		// point mid-run, isolating the RGB-vs-post-CHROM blending question from
 		// the (separately tested) weight-adaptation behaviour.
 		const fuser = new MultiRoiRppgFuser(fs, 8, 1000);
 		const rng = makeRng(99);

--- a/packages/rppg-web/src/calibration.ts
+++ b/packages/rppg-web/src/calibration.ts
@@ -1,5 +1,5 @@
 /**
- * The stage machine a reading moves through during capture — pure state
+ * The stage machine a reading moves through during capture: pure state
  * logic, no copy or presentation. Consuming apps map each stage to their own
  * label/tone (work-framing vs. recovery-framing genuinely differ per app;
  * see elata-bio-sdk#405/#24), but the ORDER these stages resolve in is the
@@ -24,7 +24,7 @@ export type CalibrationStage =
  * `adapting-light` comes FIRST and wins over everything except pause/lock: for
  * a brief window after arming, the app is still ramping its own fill-light and
  * the camera's exposure toward a stable reading of the room, and samples taken
- * during that ramp are the ones that come back "too high" — the light itself
+ * during that ramp are the ones that come back "too high"; the light itself
  * was still changing under them. During this window nothing is gathered and
  * no advice is given, because there is nothing for the READER to fix; the app
  * is still adjusting itself.

--- a/packages/rppg-web/src/cameraLiveness.ts
+++ b/packages/rppg-web/src/cameraLiveness.ts
@@ -104,10 +104,10 @@ export function initialLiveness(nowMs: number): Liveness {
  *
  * Pulled out of `observeFrame` so a caller that has NOT received a single
  * frame yet can apply the same grace period. `observeFrame` can only judge
- * "same picture as before", which needs a frame to exist in the first place —
- * a track that delivers literally zero frames (getUserMedia resolves,
+ * "same picture as before", which needs a frame to exist in the first place.
+ * A track that delivers literally zero frames (getUserMedia resolves,
  * getSettings() reports a plausible negotiation, but no decodable frame ever
- * arrives — measured on real hardware in peak-app via its cameraSweep.ts) is
+ * arrives, measured on real hardware in peak-app via its cameraSweep.ts) is
  * invisible to it. That case needs this same threshold applied to
  * elapsed-time-with-no-frame instead of elapsed-time-with-no-CHANGE.
  */

--- a/packages/rppg-web/src/captureProgress.ts
+++ b/packages/rppg-web/src/captureProgress.ts
@@ -1,7 +1,7 @@
 /**
  * How full the calibration ring is, and how strict the reading is being.
  *
- * This is the arithmetic behind a number the reader watches for ten seconds —
+ * This is the arithmetic behind a number the reader watches for ten seconds;
  * every symptom addressed below was reported by a real user and none of it
  * was visible from reading a component alone.
  */

--- a/packages/rppg-web/src/displayBpm.ts
+++ b/packages/rppg-web/src/displayBpm.ts
@@ -17,7 +17,7 @@ import { shouldAllowDisplayJumpReset } from "./displayGuard";
  * number for a cycle with no trusted value at all, is the deprecated part.
  *
  * The trusted/gated BPM that feeds baseline and state should change slowly and
- * only when confidence is high — but a UI readout that goes blank or freezes
+ * only when confidence is high, but a UI readout that goes blank or freezes
  * whenever the gate suppresses a frame looks broken. {@link DisplayBpmTracker}
  * maintains a number that keeps moving every cycle:
  *
@@ -26,7 +26,7 @@ import { shouldAllowDisplayJumpReset } from "./displayGuard";
  *  - **jump protection** ignores a >30 bpm jump from the smoothed value unless a
  *    sustained, self-consistent distant rate is seen for several cycles
  *    (persistent-disagreement catch-up) or a high-confidence tracker / reference
- *    allows it — this frees the display from a wrong initial seed without
+ *    allows it. This frees the display from a wrong initial seed without
  *    chasing transient artifacts, and
  *  - {@link hold} keeps the readout live (preferring the tracker estimate, else
  *    the last shown value) on cycles the caller suppresses entirely.

--- a/packages/rppg-web/src/displayMetrics.ts
+++ b/packages/rppg-web/src/displayMetrics.ts
@@ -8,11 +8,11 @@ export interface DisplayMetrics {
 	bpm: number | null;
 	/**
 	 * HRV (RMSSD) to render, or `null` when either the BPM-oriented publish
-	 * gate or the HRV-specific quality gate rejects this sample — see the doc
+	 * gate or the HRV-specific quality gate rejects this sample. See the doc
 	 * comment on {@link resolveDisplayMetrics}.
 	 */
 	hrvRmssd: number | null;
-	/** Coarse confidence bucket, for a caption/badge — not a gate by itself (see below). */
+	/** Coarse confidence bucket, for a caption/badge, not a gate by itself (see below). */
 	confidence: DisplayConfidence;
 	/** Whether this snapshot's vitals are fit to display at all. */
 	publishable: boolean;
@@ -36,10 +36,10 @@ const DEFAULT_CONFIDENCE_THRESHOLD = 0.35;
  *
  * The sharper failure, found while fixing neural-chat-app#10: `RppgGatingController`
  * (`rppgGating.ts`) already nulls `publishBpm` the moment a reading stops being
- * trustworthy — that part of the SDK was already correct. The bug was that each
+ * trustworthy; that part of the SDK was already correct. The bug was that each
  * app then layered its OWN smoothing (a median/EMA accumulator) on top of the
  * already-gated `publishBpm`, and that accumulator only updated "when there's a
- * fresh sample" — so the moment the SDK correctly went to `null`, the app's own
+ * fresh sample," so the moment the SDK correctly went to `null`, the app's own
  * smoothing silently kept showing its last-known value, forever, with no expiry.
  * The SDK's gating was right; the app-side re-smoothing defeated it.
  *
@@ -51,16 +51,16 @@ const DEFAULT_CONFIDENCE_THRESHOLD = 0.35;
  *
  * `confidence` is exposed for a caption ("signal unreliable") or for an app's
  * own internal math that wants to discount rather than hide (e.g. Peak's
- * confidence-weighted averaging) — it is deliberately NOT what gates `bpm`/
+ * confidence-weighted averaging); it is deliberately NOT what gates `bpm`/
  * `hrvRmssd` to null. `canPublish`/`publishBpm` already encode the SDK's own,
  * more complete trust decision (face presence, framing, motion, signal
- * quality — see `rppgGating.ts`); re-deriving that from `confidence` alone in
+ * quality, see `rppgGating.ts`); re-deriving that from `confidence` alone in
  * each app is exactly the kind of independent re-implementation that caused
  * this bug in the first place.
  *
  * `hrvRmssd` is gated by TWO decisions composed together, not `canPublish`
  * alone. `canPublish` is BPM-oriented; HRV needs a strictly tighter bar,
- * because beat-to-beat timing is far more fragile than an average rate — a
+ * because beat-to-beat timing is far more fragile than an average rate: a
  * sample can clear the BPM quality floor and still carry a garbage HRV
  * figure. `trustedHrvSample` (`hrvSampleTrust.ts`) owns exactly that second,
  * HRV-specific gate. Surfacing HRV off the BPM gate alone would silently

--- a/packages/rppg-web/src/exposureFit.ts
+++ b/packages/rppg-web/src/exposureFit.ts
@@ -4,7 +4,7 @@
  * solve directly for a target luma instead of guessing a proportional nudge.
  *
  * This is the measurement the "solve directly for the target" correction in
- * an app's own exposure-tuning decision is built on — the same principle the
+ * an app's own exposure-tuning decision is built on, the same principle the
  * rPPG exposure-control literature uses (fit the camera's actual response,
  * then invert it), scaled down from a dedicated multi-frame-per-second
  * scheme to a once-a-second luma poll: no new frames are sampled, this just
@@ -15,7 +15,7 @@
  * autoexposure, so the sensor's own AE algorithm can partly re-compensate
  * between samples, and ambient light can genuinely change for reasons
  * unrelated to the requested compensation. The fit is a best-effort local
- * estimate, not a controlled measurement — callers should guard against a
+ * estimate, not a controlled measurement, so callers should guard against a
  * nonsensical (near-zero or inverted-sign) result rather than trusting every
  * fit blindly.
  */

--- a/packages/rppg-web/src/hrvSampleTrust.ts
+++ b/packages/rppg-web/src/hrvSampleTrust.ts
@@ -5,11 +5,11 @@
  * low." Traced as far as this codebase can trace it: `hrv_rmssd` comes
  * straight from `@elata-biosciences/rppg-web` (the SDK's own doc calls it
  * "Experimental"), range-clamped in `rppg.ts` and otherwise passed through
- * unmodified — no bug in the number itself, and nothing here can improve the
+ * unmodified: no bug in the number itself, and nothing here can improve the
  * vendored SDK's estimate.
  *
  * What IS this codebase's to fix: the SDK's `BaselineCalibrator` rejects
- * outlier SAMPLES by BPM distance only (`outlierBpm`) — a frame can pass that
+ * outlier SAMPLES by BPM distance only (`outlierBpm`), so a frame can pass that
  * gate on a perfectly good beat-rate estimate while its HRV figure, which
  * needs precise beat-to-BEAT timing rather than just an average rate, is
  * garbage. rMSSD is far more sensitive to a single misdetected beat than BPM
@@ -29,8 +29,8 @@
  */
 
 /**
- * Higher than the 0.24 floor BPM gathers at. Not derived from a measurement —
- * there is no way to derive it from one without reference HRV data — chosen
+ * Higher than the 0.24 floor BPM gathers at. Not derived from a measurement:
+ * there is no way to derive it from one without reference HRV data. Chosen
  * as a meaningfully stricter bar (avoids the noisiest third of the accepted-
  * for-BPM range) rather than an arbitrary-looking number close to the BPM
  * floor that would barely change anything.

--- a/packages/rppg-web/src/index.ts
+++ b/packages/rppg-web/src/index.ts
@@ -327,7 +327,7 @@ export type {
 } from "./rppgGating";
 // --- Reliability-gating surface (elata-bio-sdk#405): every rule that decides
 // whether an rPPG number is trustworthy enough to show, gather, or average.
-// Extracted so three independent consumer apps stop hand-copying it — see
+// Extracted so three independent consumer apps stop hand-copying it. See
 // resolveDisplayMetrics above and elata-bio-sdk#24 for the failure history.
 export { HRV_TRUST_QUALITY_MIN, trustedHrvSample } from "./hrvSampleTrust";
 export {

--- a/packages/rppg-web/src/motionIndex.ts
+++ b/packages/rppg-web/src/motionIndex.ts
@@ -1,7 +1,7 @@
 /**
  * How much the face actually moved between two frames, from face-mesh landmarks.
  *
- * A head-box framing gate only knows whether the SDK's head BOX is centred —
+ * A head-box framing gate only knows whether the SDK's head BOX is centred;
  * it says nothing about motion that keeps the box roughly in place (a nod, a
  * tilt, talking), which is exactly the motion the rPPG literature identifies
  * as most disruptive to signal quality (speaking and head-shake degrade HR
@@ -9,7 +9,7 @@
  * different question than the box does: not "is the face positioned
  * correctly" but "did the face just move."
  *
- * Deliberately NOT face-box-based and NOT limited to the frame centre — every
+ * Deliberately NOT face-box-based and NOT limited to the frame centre: every
  * one of the 468 mesh points contributes, so motion at the jaw or brow (which
  * can leave the box's own centroid nearly unchanged) still registers.
  */
@@ -28,7 +28,7 @@ import type { LandmarkLike } from "./roiProfile";
  * from yaw/pitch/x-y landmark deltas, not raw 3D displacement).
  *
  * Null on either frame (no face detected, or the first frame with nothing to
- * compare against) returns 0 — "no evidence of motion," not "maximum motion."
+ * compare against) returns 0: "no evidence of motion," not "maximum motion."
  * A dropped detection is not itself motion, and treating it as such would
  * falsely gate a capture the instant the face model has one bad frame.
  */
@@ -49,7 +49,7 @@ export function landmarkMotion(
 	// interval; a deliberate head turn or nod is well over 0.01. 0.02 as the
 	// point where the score saturates to 1 leaves headroom above "clearly
 	// moving" for genuinely large motion, rather than clipping real variation
-	// into one bucket. Not derived from a measured dataset — a placeholder
+	// into one bucket. Not derived from a measured dataset; a placeholder
 	// scale chosen to be well-separated from observed stillness, tightened
 	// later against real signal-quality correlation if `motion_mean` from the
 	// WASM backend and this score are ever compared side by side.

--- a/packages/rppg-web/src/multiRoiFusion.ts
+++ b/packages/rppg-web/src/multiRoiFusion.ts
@@ -11,15 +11,15 @@ import { Bandpass, ChromPulseModel, spectralSnr } from "./rppgSignalModel";
  *
  * ## Where the weights get applied, and why it's not the obvious place
  *
- * The weights are applied to the raw RGB averages, before CHROM — not to the
+ * The weights are applied to the raw RGB averages, before CHROM, not to the
  * per-ROI CHROM outputs after the fact. Chari et al. ("Diverse R-PPG: Camera-
  * Based Heart Rate Estimation for Diverse Subject Skin-Tones and Scenes")
- * benchmarked exactly the alternative — weighting already-extracted per-ROI
- * pulse signals by their own SNR — against a diverse-skin-tone dataset and
+ * benchmarked exactly the alternative (weighting already-extracted per-ROI
+ * pulse signals by their own SNR) against a diverse-skin-tone dataset and
  * found it *increases* skin-tone bias relative to plain unweighted spatial
  * averaging. The mechanism: darker skin reflects less light, so the raw pixel
  * intensity is lower, so the photon/read-noise floor of the SENSOR (not the
- * physiology) already lowers that region's post-processing SNR — the paper's
+ * physiology) already lowers that region's post-processing SNR. The paper's
  * own noise analysis shows this bias is a camera-noise effect, not a
  * biophysical one (SIR is melanin-independent once light transport is
  * modelled). Weighting by that SNR after independently filtering each region
@@ -28,17 +28,17 @@ import { Bandpass, ChromPulseModel, spectralSnr } from "./rppgSignalModel";
  * before the region gets a fair chance to contribute.
  *
  * So: raw per-ROI RGB averages are combined into ONE weighted spatial average
- * first (the SNR-driven weights below still decide the mix — same weighting
+ * first (the SNR-driven weights below still decide the mix, same weighting
  * logic as before, only where it's applied moved), and a single shared CHROM +
  * bandpass pipeline runs on that blended stream. This is the RGB-space
  * weighting Chari et al. show closes most of the gap; per-ROI CHROM/bandpass
  * still runs independently per region (see `chrom`/`band` below) purely as
- * the SNR probe that drives the weights — it no longer feeds the fused output
+ * the SNR probe that drives the weights. It no longer feeds the fused output
  * directly.
  *
  * Honest limit: this ports the paper's RGB-space-weighting recommendation,
  * not its second, larger recommendation (an explicit skin-diffuse-component
- * weight derived from per-pixel specular-highlight detection) — this module
+ * weight derived from per-pixel specular-highlight detection). This module
  * only ever receives an already-averaged `RoiRgbSample` per region per frame,
  * not the raw per-pixel data specular detection would need. That's a bigger
  * change, tracked separately, not silently implied to already be done here.
@@ -69,7 +69,7 @@ export interface MultiRoiFusionResult {
 	/** Per-ROI in-band spectral SNR (linear) from the last weight update. */
 	snr: Record<FusionRoiName, number>;
 	/**
-	 * In-band spectral SNR (linear) of the *fused* signal — the quality scalar
+	 * In-band spectral SNR (linear) of the *fused* signal: the quality scalar
 	 * that should gate HR/HRV display. ~1 means no usable pulse.
 	 */
 	fusedSnr: number;
@@ -138,7 +138,7 @@ export class MultiRoiRppgFuser {
 		this.frame++;
 
 		// Per-ROI CHROM + bandpass still runs on every present region, but only as
-		// the SNR probe `updateWeights` reads below — it no longer feeds `fused`
+		// the SNR probe `updateWeights` reads below; it no longer feeds `fused`
 		// directly (see the module doc comment for why).
 		for (const roi of FUSION_ROIS) {
 			const s = samples[roi];
@@ -225,7 +225,7 @@ export class MultiRoiRppgFuser {
 		if (total > 0) {
 			for (const roi of FUSION_ROIS) target[roi] = raw[roi] / total;
 		} else {
-			// No region has a usable peak yet — fall back to equal weighting.
+			// No region has a usable peak yet, so fall back to equal weighting.
 			for (const roi of FUSION_ROIS) target[roi] = 1 / FUSION_ROIS.length;
 		}
 


### PR DESCRIPTION
## Summary

Cleanup pass over every file authored or edited across #25/#26/#28/#29 (this reliability-gating effort): removes em-dashes from doc comments, inline comments, test names, and changesets, replacing each with plain punctuation. Pure copy change.

Scoped intentionally to files touched by this effort. The rest of the package has pre-existing em-dashes from before this work and is out of scope here.

## Test plan

- 419/419 package tests passing (unchanged)
- `tsc --noEmit` clean
- `biome lint src` clean
- `pnpm run build` clean
- No behavior change

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoR4EBcbFgbrnMfQcUVFn8)_