### PR TITLE
fix(rppg-web): add shouldDeclareNoFrame, the correct zero-frames-ever check

### DIFF
--- a/.changeset/camera-declared-no-frame-after-real-frames.md
+++ b/.changeset/camera-declared-no-frame-after-real-frames.md
@@ -1,0 +1,23 @@
+---
+"@elata-biosciences/rppg-web": minor
+---
+
+Add `shouldDeclareNoFrame`, the correct zero-frames-ever check for a consumer
+deciding whether to tear down and reacquire a video element that has no
+decodable frame right now.
+
+`pastStartupGrace` alone (the function this module's own doc comment
+previously pointed a zero-frame caller at) gates on elapsed time only, but
+`startedAt` never moves once a real frame lands, so `pastStartupGrace` stays
+true for the rest of the session once the grace period clears. A single
+missed `readyState`/`videoWidth` tick anytime after that, even deep into an
+otherwise-healthy reading, was therefore indistinguishable from a camera that
+never started at all, and forced a mid-reading reacquire off `pastStartupGrace`
+by itself.
+
+`shouldDeclareNoFrame` additionally requires `liveness.signature` to still be
+`null` (no frame has EVER been sampled this session), the one condition that
+actually holds for "never started" and not for "started fine, one bad tick."
+Found independently in both consumer forks of this module (peak-app,
+vitality-app) before either had migrated onto this package; landing the fix
+here means neither fork (nor a future one) inherits it a third time.

--- a/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
+++ b/packages/rppg-web/src/__tests__/cameraLiveness.test.ts
@@ -5,6 +5,7 @@ import {
 	observeFrame,
 	pastStartupGrace,
 	sameSignature,
+	shouldDeclareNoFrame,
 	signatureOf,
 } from "../cameraLiveness";
 
@@ -140,6 +141,34 @@ describe("pastStartupGrace", () => {
 	test("measures from the given start, not from zero", () => {
 		expect(pastStartupGrace(50_000, 50_000 + STARTUP_GRACE_MS)).toBe(true);
 		expect(pastStartupGrace(50_000, 50_000 + STARTUP_GRACE_MS - 1)).toBe(false);
+	});
+});
+
+describe("shouldDeclareNoFrame", () => {
+	test("is false before the grace period, even with no frame ever seen", () => {
+		const state = initialLiveness(0);
+		expect(shouldDeclareNoFrame(state, STARTUP_GRACE_MS - 1)).toBe(false);
+	});
+
+	test("is true past the grace period when no frame has ever been sampled", () => {
+		const state = initialLiveness(0);
+		expect(shouldDeclareNoFrame(state, STARTUP_GRACE_MS)).toBe(true);
+	});
+
+	test("THE REGRESSION THIS EXISTS FOR: is false once a real frame has already landed, however long ago the session armed", () => {
+		// Found independently in both peak-app and vitality-app: a synthetic-pulse
+		// e2e fixture was already producing real frames when a single missed
+		// readyState/videoWidth tick, well past startedAt, read as "never
+		// started" and forced a destructive reacquire mid-reading. startedAt
+		// never moves once armed, so pastStartupGrace alone stays true for the
+		// rest of the session; only the signature check tells "never started"
+		// apart from "started fine, one bad tick".
+		let state = initialLiveness(0);
+		state = observeFrame(state, [1, 2, 3], 100); // a real frame lands early
+		// Long after the grace period, readyState/videoWidth glitches false for
+		// one tick: a consumer's paint loop calls this with the CURRENT time
+		// but the liveness object from the last successful sample, unchanged.
+		expect(shouldDeclareNoFrame(state, STARTUP_GRACE_MS * 10)).toBe(false);
 	});
 });
 

--- a/packages/rppg-web/src/cameraLiveness.ts
+++ b/packages/rppg-web/src/cameraLiveness.ts
@@ -83,36 +83,66 @@ export const FROZEN_MS = 2000;
 export const STARTUP_GRACE_MS = FROZEN_MS * 2;
 
 export type Liveness = {
-  /** The last picture we saw, or null before the first sample. */
-  readonly signature: readonly number[] | null;
-  /** When the picture last differed from the one before it. */
-  readonly changedAt: number;
-  /** When the first sample was taken. Fixed for the life of one session, so
-   *  the startup grace is measured from arming, not from the last change. */
-  readonly startedAt: number;
-  /** Nothing has changed for {@link FROZEN_MS}, and we are past
-   *  {@link STARTUP_GRACE_MS}. */
-  readonly frozen: boolean;
+	/** The last picture we saw, or null before the first sample. */
+	readonly signature: readonly number[] | null;
+	/** When the picture last differed from the one before it. */
+	readonly changedAt: number;
+	/** When the first sample was taken. Fixed for the life of one session, so
+	 *  the startup grace is measured from arming, not from the last change. */
+	readonly startedAt: number;
+	/** Nothing has changed for {@link FROZEN_MS}, and we are past
+	 *  {@link STARTUP_GRACE_MS}. */
+	readonly frozen: boolean;
 };
 
 export function initialLiveness(nowMs: number): Liveness {
-  return { signature: null, changedAt: nowMs, startedAt: nowMs, frozen: false };
+	return { signature: null, changedAt: nowMs, startedAt: nowMs, frozen: false };
 }
 
 /**
  * Has enough time passed since the first sample to trust a stillness verdict?
  *
- * Pulled out of `observeFrame` so a caller that has NOT received a single
- * frame yet can apply the same grace period. `observeFrame` can only judge
- * "same picture as before", which needs a frame to exist in the first place.
- * A track that delivers literally zero frames (getUserMedia resolves,
- * getSettings() reports a plausible negotiation, but no decodable frame ever
- * arrives, measured on real hardware in peak-app via its cameraSweep.ts) is
- * invisible to it. That case needs this same threshold applied to
- * elapsed-time-with-no-frame instead of elapsed-time-with-no-CHANGE.
+ * Pulled out of `observeFrame` so `shouldDeclareNoFrame` (below) can apply
+ * the same grace period to a caller that has NOT received a single frame
+ * yet. `observeFrame` can only judge "same picture as before", which needs a
+ * frame to exist in the first place, a track that delivers literally zero
+ * frames (getUserMedia resolves, getSettings() reports a plausible
+ * negotiation, but no decodable frame ever arrives; measured on real
+ * hardware in peak-app via its cameraSweep.ts) is invisible to it.
+ *
+ * A zero-frame caller should use `shouldDeclareNoFrame`, not this function
+ * directly: this alone only measures elapsed time, and elapsed time alone
+ * cannot tell "never started" apart from "started fine a while ago, missed
+ * one tick" once the grace period has cleared. Exported because
+ * `observeFrame`'s own frozen check also needs it.
  */
 export function pastStartupGrace(startedAtMs: number, nowMs: number): boolean {
-  return nowMs - startedAtMs >= STARTUP_GRACE_MS;
+	return nowMs - startedAtMs >= STARTUP_GRACE_MS;
+}
+
+/**
+ * Should a video element with no decodable frame right now be declared "never
+ * started" and torn down for a reacquire?
+ *
+ * Only when NO frame has EVER been sampled this session ({@link
+ * Liveness.signature} still `null`): `startedAt` is fixed at arming and never
+ * moves once a real frame lands, so `pastStartupGrace` alone stays true for
+ * the rest of the session. Without the signature check, a single missed tick
+ * long after a healthy session was already producing real frames (a busy
+ * main thread during heavy rPPG/WASM work, e.g.) reads identically to a
+ * track that never delivered anything, and forces a destructive reacquire in
+ * the middle of an otherwise-fine reading. Found independently in both
+ * consumer forks of this module (peak-app and vitality-app) before either
+ * had migrated onto this package, which is the reason this fix lives here
+ * now instead of a third time in a third fork.
+ */
+export function shouldDeclareNoFrame(
+	liveness: Liveness,
+	nowMs: number,
+): boolean {
+	return (
+		liveness.signature === null && pastStartupGrace(liveness.startedAt, nowMs)
+	);
 }
 
 /**
@@ -122,18 +152,21 @@ export function pastStartupGrace(startedAtMs: number, nowMs: number): boolean {
  * it would be a quarter of the comparison spent on a constant.
  */
 export function signatureOf(pixels: ArrayLike<number>): number[] {
-  const out: number[] = [];
-  for (let i = 0; i + 2 < pixels.length; i += 4) {
-    out.push(pixels[i], pixels[i + 1], pixels[i + 2]);
-  }
-  return out;
+	const out: number[] = [];
+	for (let i = 0; i + 2 < pixels.length; i += 4) {
+		out.push(pixels[i], pixels[i + 1], pixels[i + 2]);
+	}
+	return out;
 }
 
 /** Exact equality. One count of difference in one sample is a living camera. */
-export function sameSignature(a: readonly number[], b: readonly number[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-  return true;
+export function sameSignature(
+	a: readonly number[],
+	b: readonly number[],
+): boolean {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+	return true;
 }
 
 /**
@@ -143,18 +176,23 @@ export function sameSignature(a: readonly number[], b: readonly number[]): boole
  * a camera, a dark room, or a timer.
  */
 export function observeFrame(
-  prev: Liveness,
-  signature: readonly number[],
-  nowMs: number,
+	prev: Liveness,
+	signature: readonly number[],
+	nowMs: number,
 ): Liveness {
-  if (prev.signature === null || !sameSignature(prev.signature, signature)) {
-    return { signature, changedAt: nowMs, startedAt: prev.startedAt, frozen: false };
-  }
-  const past = pastStartupGrace(prev.startedAt, nowMs);
-  return {
-    signature: prev.signature,
-    changedAt: prev.changedAt,
-    startedAt: prev.startedAt,
-    frozen: past && nowMs - prev.changedAt >= FROZEN_MS,
-  };
+	if (prev.signature === null || !sameSignature(prev.signature, signature)) {
+		return {
+			signature,
+			changedAt: nowMs,
+			startedAt: prev.startedAt,
+			frozen: false,
+		};
+	}
+	const past = pastStartupGrace(prev.startedAt, nowMs);
+	return {
+		signature: prev.signature,
+		changedAt: prev.changedAt,
+		startedAt: prev.startedAt,
+		frozen: past && nowMs - prev.changedAt >= FROZEN_MS,
+	};
 }

--- a/packages/rppg-web/src/index.ts
+++ b/packages/rppg-web/src/index.ts
@@ -357,6 +357,7 @@ export {
 	initialLiveness,
 	observeFrame,
 	pastStartupGrace,
+	shouldDeclareNoFrame,
 	sameSignature,
 	signatureOf,
 } from "./cameraLiveness";


### PR DESCRIPTION
## Summary

`pastStartupGrace` alone gates the zero-frames-ever check on elapsed time only, but `startedAt` never moves once a real frame lands, so `pastStartupGrace` stays true for the rest of the session once the grace period clears. A single missed `readyState`/`videoWidth` tick anytime after that, even deep into an otherwise-healthy reading, was indistinguishable from a camera that never started at all, and this module's own doc comment previously pointed a zero-frame caller at `pastStartupGrace` directly for exactly this check.

Found independently in both consumer forks of this module (`peak-app`, `vitality-app`) before either had migrated onto this package both hit the same bug in their own duplicated copy of `cameraLiveness.ts` and fixed it the same way, which is what surfaced that the underlying issue traces back to this package's own (unexported) implementation of the pattern.

## The fix

Adds `shouldDeclareNoFrame(liveness, nowMs)`, gated on `liveness.signature` also still being `null` (no frame has EVER been sampled this session) in addition to the elapsed-time check the one condition that actually holds for "never started" and not for "started fine, one bad tick." Exported from the package, and `pastStartupGrace`'s own doc comment updated to point zero-frame callers at the new function instead.

## Why this belongs here rather than in each app

Both `peak-app` and `vitality-app` are migrating their camera-liveness detection onto this package instead of maintaining their own forked copies (tracking: `peak-app#405`). Landing the fix here first means neither app (nor a future consumer) inherits the bug a third time.

## Test plan

- [x] New unit tests (`shouldDeclareNoFrame`) that fail without the signature check and pass with it, verified by reverting the fix and watching the regression test go red, then restoring it
- [x] `pnpm test` in `packages/rppg-web` - 16/16 passing
- [x] `pnpm build` in `packages/rppg-web` - clean
- [x] `biome check` - clean (also reformatted `cameraLiveness.ts`, which had drifted to 2-space indentation from its origin as a copied-in module; no logic change)
- [x] Changeset added (minor bump, new export)

## Downstream

`peak-app` and `vitality-app` both have migration branches ready (deleting their local `cameraLiveness.ts` forks in favor of importing from this package) that depend on this landing and publishing. Not pushed yet but waiting on this PR.

cc @Cartev112  - you own this module's history (`elata-bio-sdk#28`) and there are several other pending changesets queued in `.changeset/`, so the release timing/bundling is your call, not something I want to trigger unilaterally.